### PR TITLE
Open-source prep: rename to metron, README rewrite, LICENSE, quick-start

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Chris Conley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,138 @@
-# metering-spec
+# metron
 
-Data contracts and a Go reference implementation for usage metering — the part of billing that answers "how much did each customer use?"
+Data contracts and a Go reference implementation for metering — the part of billing that answers "how much did each customer use?"
 
-That question is harder than it sounds. Your API emits events with a bag of properties (`input_tokens`, `output_tokens`, `model`, `region`). Some of those properties are quantities you bill for. Others are dimensions you filter by. Different event types need different extraction rules. Some customers are metered by total usage (sum), others by peak concurrent usage (max), others by average seat count weighted across the billing period (time-weighted average). Your test environment needs to run the same pipeline as production without cross-contaminating billing data. And every number has to be exact — no floating-point drift in financial calculations.
+> Pre-1.0. The core pipeline works and is tested. The data contracts are actively evolving. Expect breaking changes.
 
-This spec defines the data shapes and pure functions for that pipeline: take raw events in, get billable quantities out.
+That question is harder than it sounds. Your API emits events with a bag of properties (`input_tokens`, `output_tokens`, `model`, `region`). Some are quantities you bill for. Others are dimensions you filter by. Different event types need different extraction rules.
 
-## How it works
+Then aggregation gets interesting. Some customers are metered by total usage (sum), others by peak concurrent usage (max), others by average seat count weighted across the billing period. If a customer had 10 seats for 20 days then 15 seats for 10 days, the time-weighted average is 11.67 — not 12.5. Every number has to be exact: no floating-point drift in financial calculations.
 
-The pipeline has two stages. First, **extract** measurements from raw events. Then, **aggregate** those measurements over billing windows.
+This is a spec and a reference implementation, not a platform you deploy. It defines data shapes and pure functions for the metering pipeline: take raw events in, get billable quantities out. You own the infrastructure.
 
-**A raw usage event** — your application emits these with whatever properties are relevant:
+## Try it
+
+```bash
+git clone https://github.com/chrisconley/metron.git
+cd metron
+go run ./examples/hello
+```
+
+```
+customer:acme-corp used 11.67 seats (time-weighted-avg) from 2024-01-01 to 2024-01-31
+```
+
+That's the 11.67 from above, computed end-to-end: two gauge events (10 seats at Jan 1, 15 seats at Jan 21) become one billable reading for January. The whole program is one file:
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/cockroachdb/apd/v3"
+
+	"github.com/chrisconley/metron/internal"
+	"github.com/chrisconley/metron/specs"
+)
+
+func main() {
+	// Extract the "seats" property as an observation with unit "seats".
+	meteringConfig := specs.MeteringConfigSpec{
+		Observations: []specs.ObservationExtractionSpec{
+			{SourceProperty: "seats", Unit: "seats"},
+		},
+	}
+
+	// Two gauge events: 10 seats at Jan 1, then 15 seats at Jan 21.
+	events := []specs.EventPayloadSpec{
+		{
+			ID: "evt_1", Type: "subscription.gauge",
+			WorkspaceID: "acme-prod", UniverseID: "production",
+			Subject:    "customer:acme-corp",
+			Time:       time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			Properties: map[string]string{"seats": "10"},
+		},
+		{
+			ID: "evt_2", Type: "subscription.gauge",
+			WorkspaceID: "acme-prod", UniverseID: "production",
+			Subject:    "customer:acme-corp",
+			Time:       time.Date(2024, 1, 21, 0, 0, 0, 0, time.UTC),
+			Properties: map[string]string{"seats": "15"},
+		},
+	}
+
+	// Stage 1 — Meter: event → records.
+	var records []specs.MeterRecordSpec
+	for _, event := range events {
+		recs, err := internal.Meter(event, meteringConfig)
+		if err != nil {
+			log.Fatalf("meter: %v", err)
+		}
+		records = append(records, recs...)
+	}
+
+	// Stage 2 — Aggregate: records → one reading over the billing window.
+	reading, err := internal.Aggregate(records, nil, specs.AggregateConfigSpec{
+		Aggregation: "time-weighted-avg",
+		Window: specs.TimeWindowSpec{
+			Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			End:   time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	if err != nil {
+		log.Fatalf("aggregate: %v", err)
+	}
+
+	// The underlying quantity is exact (11.666…); round to cents for display.
+	value := reading.ComputedValues[0]
+	fmt.Printf("%s used %s %s (%s) from %s to %s\n",
+		reading.Subject, roundCents(value.Quantity), value.Unit, value.Aggregation,
+		reading.Window.Start.Format("2006-01-02"), reading.Window.End.Format("2006-01-02"),
+	)
+}
+
+func roundCents(s string) string {
+	var parsed, rounded apd.Decimal
+	parsed.SetString(s)
+	apd.BaseContext.WithPrecision(34).Quantize(&rounded, &parsed, -2)
+	return rounded.String()
+}
+```
+
+Source: [`examples/hello/main.go`](examples/hello/main.go). The output line is asserted by a test, so it can't drift from the code.
+
+### Going deeper
+
+- **[Basic API metering walkthrough](docs/examples/basic-api-metering.md)** — step through each pipeline stage with JSON examples.
+- **Production-style pipeline** — 300 events over 30 seconds through an event bus, multiple aggregators at different time scales, and a rating handler firing threshold alerts. Source: [`internal/examples/`](internal/examples/). Run it: `go test -v ./internal/examples/ -run TestHighThroughputMeteringPipeline`.
+
+The Go reference implementation lives in `internal/`. The portable data contracts — language-agnostic Go structs with JSON tags — live in `specs/`, designed to be re-implemented in any language.
+
+## Why this design
+
+**No code changes for new billing models.** Extraction rules, filters, units, and aggregation strategies are all configuration. When a new product launches or a pricing model changes, you update a metering config — engineering doesn't touch the pipeline.
+
+**Any pricing model.** Usage-based billing needs token counts. Seat-based pricing needs time-weighted seat averages. Hybrid models need both. Even flat-rate plans with overage clauses need to know when a customer exceeds their commitment. The metering layer produces quantities; it doesn't know or care which pricing model consumes them.
+
+**One event, one record.** All observations extracted from a single event are bundled in one MeterRecord. Persistence is atomic — all observations save together or none do. No partial event data in the pipeline. See [meterrecord-atomicity-analysis.md](design/references/meterrecord-atomicity-analysis.md) for the full design rationale.
+
+**No schema coordination.** Event properties are untyped strings. Teams add new properties to their events without coordinating across the metering system. The metering config — not the event schema — decides what gets extracted.
+
+**Replay-safe.** Pure functions with deterministic IDs. Reprocessing the same events with the same configuration produces identical records. No hidden state, no side effects, no order dependence.
+
+**Exact arithmetic.** All quantities are decimal strings (`"123.45"`, not `123.45`). No floating-point anywhere. The Go implementation uses [`cockroachdb/apd`](https://github.com/cockroachdb/apd) for arbitrary-precision decimal arithmetic.
+
+**Test and production in one pipeline.** Workspace × universe scoping isolates data without separate infrastructure. Run test events through the same pipeline as production without cross-contamination.
+
+## What the pipeline does
+
+Events arrive from your application with a bag of untyped string properties. The pipeline transforms them into billable quantities through a series of configurable steps.
+
+### 1. Accept events with untyped properties
+
 ```json
 {
   "id": "evt_abc123",
@@ -26,7 +148,26 @@ The pipeline has two stages. First, **extract** measurements from raw events. Th
 }
 ```
 
-**An extraction config** — tells the pipeline which properties are quantities and what units to assign:
+Properties are `map[string]string`, not a typed schema. This is deliberate. Different products emit different properties without coordinating schema changes across the metering system. The metering config decides what matters — not the event schema.
+
+### 2. Filter by property values
+
+Not every event produces the same observations. A metering config can include filters that match on property values:
+
+```json
+{
+  "sourceProperty": "request_count",
+  "unit": "premium-requests",
+  "filter": { "property": "tier", "equals": "premium" }
+}
+```
+
+This lets you meter the same event type differently based on customer tier, region, product variant, or any other property — through configuration, not code branches.
+
+### 3. Extract quantities and assign units
+
+The config specifies which properties are quantities and what unit to assign:
+
 ```json
 {
   "observations": [
@@ -36,20 +177,18 @@ The pipeline has two stages. First, **extract** measurements from raw events. Th
 }
 ```
 
-**A metered record** — the extracted quantities (observations) with remaining properties preserved as dimensions:
-```json
-{
-  "id": "evt_abc123",
-  "subject": "customer:cust_123",
-  "observations": [
-    { "quantity": "1250", "unit": "input-tokens", "window": { "start": "...", "end": "..." } },
-    { "quantity": "340", "unit": "output-tokens", "window": { "start": "...", "end": "..." } }
-  ],
-  "dimensions": { "model": "gpt-4", "region": "us-east" }
-}
-```
+Each extraction parses the string value into an exact decimal, pairs it with a unit, and timestamps it with the event's time. The same source property can map to different units depending on which filter matched — `request_count` becomes `premium-requests` or `standard-requests` based on the customer's tier.
 
-**A billable quantity** — observations aggregated over a billing window:
+### 4. Preserve remaining properties as dimensions
+
+Properties not extracted as quantities (`model`, `region` in the example above) become **dimensions** on the metered record — preserved for filtering and grouping downstream ("show me token usage broken down by model and region").
+
+The distinction matters: quantities get aggregated (summed, maxed, averaged). Dimensions get preserved (for grouping, filtering, reporting). You don't have to decide up front which properties you'll want to group by later — everything that isn't a quantity is kept.
+
+### 5. Aggregate over billing windows
+
+Observations are combined over a time window using a configured [aggregation strategy](#aggregation-strategies):
+
 ```json
 {
   "subject": "customer:cust_123",
@@ -61,9 +200,7 @@ The pipeline has two stages. First, **extract** measurements from raw events. Th
 }
 ```
 
-This is where metering-spec's job ends. The reading says "customer cust_123 used 125,000 input-tokens this month." What that costs is a pricing/rating concern handled elsewhere.
-
-Properties that aren't extracted as observations (`model`, `region`) become **dimensions** — available for filtering and grouping downstream.
+This is where metron's job ends. The reading says "customer cust_123 used 125,000 input-tokens this month." What that costs is a pricing/rating concern handled elsewhere.
 
 ## Who this is for
 
@@ -75,30 +212,17 @@ You're building a system where:
 - **Billing periods matter** — you need to window usage into hourly, daily, or monthly buckets for invoicing
 - **Precision matters** — you're doing financial math and can't tolerate floating-point drift
 
-This spec doesn't handle pricing, invoicing, payments, or revenue recognition. It produces the quantities that those systems consume.
+## Scope
 
-## Running it
+Metering-spec handles the **quantity pipeline**: raw events in, billable quantities out. It stops at the boundary where quantities become money.
 
-```bash
-git clone https://github.com/chrisconley/potential-telegram.git
-cd potential-telegram
-go test ./...
-```
+**In scope:** observation extraction, unit assignment, dimensional filtering, time-windowed aggregation, multi-tenant isolation, exact decimal arithmetic.
 
-The Go reference implementation lives in `internal/`. The two core functions:
+**Out of scope:** pricing, rating, tiered rates, overage charges, committed-use discounts, credits, rollover, proration across billing periods, invoicing, payments, revenue recognition.
 
-```go
-import (
-    "metering-spec/internal"
-    "metering-spec/specs"
-)
+The boundary is intentional. Pricing logic depends on business rules that change per customer, per contract, per negotiation — "this customer gets a volume discount above 100k tokens" or "roll unused credits into next month." Those computations take metering quantities as *input* but aren't metering themselves. Conflating the two makes both harder to change independently.
 
-// Stage 1: Meter an event — extract observations from properties
-records, err := internal.Meter(eventPayload, meteringConfig)
-
-// Stage 2: Aggregate records — combine over a billing window
-reading, err := internal.Aggregate(records, lastBeforeWindow, aggregateConfig)
-```
+The spec does preserve temporal context on observations (both instant events and time-spanning measurements like compute sessions) so that downstream consumers have the information they need for proration and period assignment. See [observation-temporal-context.md](design/observation-temporal-context.md) for the design rationale.
 
 ## Aggregation strategies
 
@@ -110,7 +234,7 @@ reading, err := internal.Aggregate(records, lastBeforeWindow, aggregateConfig)
 | **latest** | Current state | Most recent gauge reading |
 | **time-weighted-avg** | Average over time | Seat count across a billing month |
 
-Time-weighted average treats each observation as a step function — if a customer had 10 seats for 20 days then 15 seats for 10 days, the average is 11.67, not 12.5.
+Time-weighted average treats each observation as a step function. This matters when the value changes mid-period: 10 seats for 20 days then 15 seats for 10 days averages to 11.67, not 12.5 (which is what you'd get from a naive mean of the two values). See [aggregation-types.md](design/aggregation-types.md) for the full design rationale.
 
 ## Multi-tenant isolation
 
@@ -119,43 +243,15 @@ Events are scoped by two dimensions:
 - **Workspace** — operational boundary (US region, EU region, a business unit). Each workspace owns its event schemas and metering configs.
 - **Universe** — data namespace (production, test, staging, simulation). The same customer ID in different universes is a different billing entity.
 
-This means you can run test data through the same pipeline as production without cross-contamination, or meter the same customer differently in different regions.
-
-See [workspace-universe-isolation.md](design/workspace-universe-isolation.md) for the full design rationale.
-
-## Conditional metering
-
-Extract different observations based on event properties using filters:
-
-```json
-{
-  "observations": [
-    {
-      "sourceProperty": "request_count",
-      "unit": "premium-requests",
-      "filter": { "property": "tier", "equals": "premium" }
-    },
-    {
-      "sourceProperty": "request_count",
-      "unit": "standard-requests",
-      "filter": { "property": "tier", "equals": "standard" }
-    }
-  ]
-}
-```
-
-Same event type, different units based on customer tier. Downstream, premium and standard requests can be rated at different prices.
-
-## Precision
-
-All quantities are decimal strings (`"123.45"`, not `123.45`). No floating-point anywhere in the spec. The Go implementation uses [`cockroachdb/apd`](https://github.com/cockroachdb/apd) for arbitrary-precision decimal arithmetic.
+This means you can run test data through the same pipeline as production without cross-contamination, or meter the same customer differently in different regions. See [workspace-universe-isolation.md](design/workspace-universe-isolation.md) for the design rationale.
 
 ## Repository structure
 
 ```
 specs/           Data contracts (language-agnostic Go structs with JSON tags)
 internal/        Go reference implementation (Meter, Aggregate)
-  examples/      Working end-to-end pipeline example
+  examples/      Production-style pipeline example
+examples/        Runnable quick-start example
 design/          Architecture decision records
 docs/examples/   Walkthrough guides
 benchmarks/      Performance tests
@@ -168,10 +264,6 @@ benchmarks/      Performance tests
 - **[Observation Temporal Context](design/observation-temporal-context.md)** — instant vs. time-spanning observations
 - **[Aggregation Types](design/aggregation-types.md)** — design rationale for aggregation strategies
 
-## Status
-
-Pre-1.0. The core pipeline (event → meter → aggregate) works and is tested. The data contracts are actively evolving. Expect breaking changes.
-
 ## License
 
-[To be determined]
+MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,32 +1,19 @@
-# Metering Specification
+# metering-spec
 
-**Experimental prototype** for usage metering and billing aggregation.
+Data contracts and a Go reference implementation for usage metering — the part of billing that answers "how much did each customer use?"
 
-This is a work-in-progress exploration of data contracts for metering pipelines. Expect breaking changes as we iterate based on real-world feedback.
+That question is harder than it sounds. Your API emits events with a bag of properties (`input_tokens`, `output_tokens`, `model`, `region`). Some of those properties are quantities you bill for. Others are dimensions you filter by. Different event types need different extraction rules. Some customers are metered by total usage (sum), others by peak concurrent usage (max), others by average seat count weighted across the billing period (time-weighted average). Your test environment needs to run the same pipeline as production without cross-contaminating billing data. And every number has to be exact — no floating-point drift in financial calculations.
 
-## What is this?
+This spec defines the data shapes and pure functions for that pipeline: take raw events in, get billable quantities out.
 
-This spec defines data contracts for transforming raw usage events into billable meter readings. It provides a complete pipeline from event ingestion through metering to time-windowed aggregation, with built-in support for multi-tenancy, test isolation, and flexible attribution models.
+## How it works
 
-## Why does this exist?
+The pipeline has two stages. First, **extract** measurements from raw events. Then, **aggregate** those measurements over billing windows.
 
-Building usage-based billing systems requires solving the same problems repeatedly:
-- **Flexible event schemas** - Different products need different properties without coordinating type changes
-- **Multi-tenant isolation** - Regional workspaces with global customers, test/prod separation, post-merger integration
-- **Conditional metering** - Extract different measurements based on event properties
-- **Time-windowed aggregation** - Sum, max, time-weighted-average over billing periods
-- **Precision** - Exact decimal arithmetic for financial calculations
-
-This spec explores a data model for these problems, with a Go reference implementation.
-
-## Quick Example
-
-**Input:** Raw usage event
+**A raw usage event** — your application emits these with whatever properties are relevant:
 ```json
 {
   "id": "evt_abc123",
-  "workspaceID": "acme-prod",
-  "universeID": "production",
   "type": "llm.completion",
   "subject": "customer:cust_123",
   "time": "2024-01-15T10:30:00Z",
@@ -39,157 +26,152 @@ This spec explores a data model for these problems, with a Go reference implemen
 }
 ```
 
-**Metering config:** Extract token measurements
+**An extraction config** — tells the pipeline which properties are quantities and what units to assign:
 ```json
 {
-  "measurements": [
-    {
-      "sourceProperty": "input_tokens",
-      "unit": "input-tokens"
-    },
-    {
-      "sourceProperty": "output_tokens",
-      "unit": "output-tokens"
-    }
+  "observations": [
+    { "sourceProperty": "input_tokens", "unit": "input-tokens" },
+    { "sourceProperty": "output_tokens", "unit": "output-tokens" }
   ]
 }
 ```
 
-**Output:** Metered usage record (one record with bundled observations)
+**A metered record** — the extracted quantities (observations) with remaining properties preserved as dimensions:
 ```json
 {
   "id": "evt_abc123",
   "subject": "customer:cust_123",
   "observations": [
-    {
-      "quantity": "1250",
-      "unit": "input-tokens",
-      "window": {
-        "start": "2024-01-15T10:30:00Z",
-        "end": "2024-01-15T10:30:00Z"
-      }
-    },
-    {
-      "quantity": "340",
-      "unit": "output-tokens",
-      "window": {
-        "start": "2024-01-15T10:30:00Z",
-        "end": "2024-01-15T10:30:00Z"
-      }
-    }
+    { "quantity": "1250", "unit": "input-tokens", "window": { "start": "...", "end": "..." } },
+    { "quantity": "340", "unit": "output-tokens", "window": { "start": "...", "end": "..." } }
   ],
-  "dimensions": {
-    "model": "gpt-4",
-    "region": "us-east"
-  },
-  "observedAt": "2024-01-15T10:30:00Z"
+  "dimensions": { "model": "gpt-4", "region": "us-east" }
 }
 ```
 
-**Aggregation:** Sum over billing period
+**A billable quantity** — observations aggregated over a billing window:
 ```json
 {
   "subject": "customer:cust_123",
-  "value": {
-    "quantity": "125000",
-    "unit": "input-tokens"
-  },
-  "aggregation": "sum",
-  "window": {
-    "start": "2024-01-15T00:00:00Z",
-    "end": "2024-01-16T00:00:00Z"
-  },
+  "computedValues": [
+    { "quantity": "125000", "unit": "input-tokens", "aggregation": "sum" }
+  ],
+  "window": { "start": "2024-01-01T00:00:00Z", "end": "2024-02-01T00:00:00Z" },
   "recordCount": 100
 }
 ```
 
-## Key Features
+This is where metering-spec's job ends. The reading says "customer cust_123 used 125,000 input-tokens this month." What that costs is a pricing/rating concern handled elsewhere.
 
-### Two-Dimensional Isolation
+Properties that aren't extracted as observations (`model`, `region`) become **dimensions** — available for filtering and grouping downstream.
 
-**Workspace × Universe** model enables:
-- Multi-region with global customers (different schemas per region, shared customer identity)
-- Test/staging/production separation (isolate test data from production billing)
-- What-if scenarios and simulations (parallel universes for pricing experiments)
-- Post-merger integration (namespace legacy systems without ID collisions)
+## Who this is for
 
-See [workspace-universe-isolation.md](design/workspace-universe-isolation.md) for design rationale.
+You're building a system where:
 
-### Flexible Event Schemas
+- **Customers are billed based on what they use** — API calls, tokens, compute hours, storage, seats, or any countable resource
+- **Usage events come from multiple sources** with different schemas, and you need a consistent metering layer
+- **Aggregation isn't just "sum"** — you need peak usage (max), time-weighted averages (seat count over a month), or latest-value gauges
+- **Billing periods matter** — you need to window usage into hourly, daily, or monthly buckets for invoicing
+- **Precision matters** — you're doing financial math and can't tolerate floating-point drift
 
-Events use untyped `properties` maps, allowing each workspace to define custom schemas without coordinating type system changes. Metering configs extract typed measurements at processing time.
+This spec doesn't handle pricing, invoicing, payments, or revenue recognition. It produces the quantities that those systems consume.
 
-### Conditional Metering
+## Running it
 
-Extract different measurements based on event properties. For example, meter requests differently based on customer tier or region.
+```bash
+git clone https://github.com/chrisconley/potential-telegram.git
+cd potential-telegram
+go test ./...
+```
 
-### Aggregation Strategies
+The Go reference implementation lives in `internal/`. The two core functions:
 
-- **sum** - Total usage (API calls, tokens consumed)
-- **max** - Peak usage (concurrent connections, queue depth)
-- **min** - Minimum value in window
-- **latest** - Most recent value by timestamp
-- **time-weighted-avg** - Average weighted by duration (seat count, resource allocation)
+```go
+import (
+    "metering-spec/internal"
+    "metering-spec/specs"
+)
 
-### Language Interoperability
+// Stage 1: Meter an event — extract observations from properties
+records, err := internal.Meter(eventPayload, meteringConfig)
 
-All specs use primitives-only types (strings, numbers, time) with JSON serialization. Includes Go reference implementation in `internal/`.
+// Stage 2: Aggregate records — combine over a billing window
+reading, err := internal.Aggregate(records, lastBeforeWindow, aggregateConfig)
+```
 
-### Precision and Financial Calculations
+## Aggregation strategies
 
-Quantities in metering-spec are represented as **decimal strings** (e.g., `"123.45"`) to avoid floating-point precision issues in JSON serialization.
+| Strategy | Use case | Example |
+|----------|----------|---------|
+| **sum** | Cumulative usage | Total API calls, tokens consumed |
+| **max** | Peak usage | Concurrent connections, queue depth |
+| **min** | Minimum in window | Lowest price, minimum inventory |
+| **latest** | Current state | Most recent gauge reading |
+| **time-weighted-avg** | Average over time | Seat count across a billing month |
 
-For **billing and financial use cases**, implementations SHOULD:
-- Use exact decimal arithmetic (no floating point)
-- Implement consistent rounding rules (recommend: banker's rounding / half-to-even)
-- Ensure reproducible calculations (same inputs → same outputs)
-- Guarantee allocation totals when splitting values (sum of parts = original whole)
+Time-weighted average treats each observation as a step function — if a customer had 10 seats for 20 days then 15 seats for 10 days, the average is 11.67, not 12.5.
 
-**Go implementations:** See [`cockroachdb/apd/v3`](https://github.com/cockroachdb/apd) for exact decimal arithmetic suitable for financial calculations. This repo's [`internal/decimal.go`](internal/decimal.go) provides a minimal reference wrapper.
+## Multi-tenant isolation
 
-**Other languages:** Consider decimal libraries appropriate for financial calculations:
-- Python: `decimal.Decimal` (stdlib)
-- JavaScript: `bignumber.js`, `decimal.js`
-- Java: `java.math.BigDecimal`
-- Ruby: `BigDecimal` (stdlib)
+Events are scoped by two dimensions:
+
+- **Workspace** — operational boundary (US region, EU region, a business unit). Each workspace owns its event schemas and metering configs.
+- **Universe** — data namespace (production, test, staging, simulation). The same customer ID in different universes is a different billing entity.
+
+This means you can run test data through the same pipeline as production without cross-contamination, or meter the same customer differently in different regions.
+
+See [workspace-universe-isolation.md](design/workspace-universe-isolation.md) for the full design rationale.
+
+## Conditional metering
+
+Extract different observations based on event properties using filters:
+
+```json
+{
+  "observations": [
+    {
+      "sourceProperty": "request_count",
+      "unit": "premium-requests",
+      "filter": { "property": "tier", "equals": "premium" }
+    },
+    {
+      "sourceProperty": "request_count",
+      "unit": "standard-requests",
+      "filter": { "property": "tier", "equals": "standard" }
+    }
+  ]
+}
+```
+
+Same event type, different units based on customer tier. Downstream, premium and standard requests can be rated at different prices.
+
+## Precision
+
+All quantities are decimal strings (`"123.45"`, not `123.45`). No floating-point anywhere in the spec. The Go implementation uses [`cockroachdb/apd`](https://github.com/cockroachdb/apd) for arbitrary-precision decimal arithmetic.
+
+## Repository structure
+
+```
+specs/           Data contracts (language-agnostic Go structs with JSON tags)
+internal/        Go reference implementation (Meter, Aggregate)
+  examples/      Working end-to-end pipeline example
+design/          Architecture decision records
+docs/examples/   Walkthrough guides
+benchmarks/      Performance tests
+```
 
 ## Documentation
 
-- **[Basic Example](docs/examples/basic-api-metering.md)** - Simple walkthrough with JSON examples
-- **[Architecture](docs/architecture.md)** - Pipeline stages and data flow
-- **[API Reference](specs/)** - Inline documentation for all data types
-- **[Core Concepts](docs/concepts.md)** - Workspace, Universe, Subject, Measurements, Aggregations
-- **[Production Patterns](docs/examples/production-patterns.md)** - High-throughput metering pipeline
-- **[Design Rationale](docs/design/)** - Architecture decision records
-
-## Repository Structure
-
-```
-metering-spec/
-├── specs/           # Primitives-only data contracts (language-agnostic)
-│   ├── eventpayload.go
-│   ├── meterrecord.go
-│   ├── meterreading.go
-│   └── ...
-├── internal/        # Go reference implementation
-│   ├── meter.go     # EventPayload → MeterRecord transformation
-│   ├── aggregate.go # MeterRecord → MeterReading aggregation
-│   └── examples/    # Working code examples
-└── docs/            # Conceptual documentation and guides
-```
+- **[Basic API Metering](docs/examples/basic-api-metering.md)** — step-by-step walkthrough with JSON examples
+- **[Workspace-Universe Isolation](design/workspace-universe-isolation.md)** — why two dimensions, not one
+- **[Observation Temporal Context](design/observation-temporal-context.md)** — instant vs. time-spanning observations
+- **[Aggregation Types](design/aggregation-types.md)** — design rationale for aggregation strategies
 
 ## Status
 
-**Experimental prototype.** This spec is actively evolving based on design principles and real-world requirements. The core data model is being refined through [Architecture Decision Records](design/) that guide implementation work.
+Pre-1.0. The core pipeline (event → meter → aggregate) works and is tested. The data contracts are actively evolving. Expect breaking changes.
 
-**Current state:**
-- [design/](design/) contains working ADRs that define the target design
-- [GitHub Issues](https://github.com/chrisconley/potential-telegram/issues) track active implementation work
+## License
 
-Expect breaking changes. Nothing is stable yet.
-
-If you're implementing this, please share feedback on what works and what doesn't.
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on proposing changes to the spec.
+[To be determined]

--- a/arch/work/issue-04-atomicity-migration-plan.md
+++ b/arch/work/issue-04-atomicity-migration-plan.md
@@ -1,7 +1,7 @@
 # Issue #4: MeterRecord Atomicity Migration Plan
 
 **Date:** 2026-01-28
-**Issue:** [#4 Bundle multiple observations in single MeterRecord for atomicity](https://github.com/chrisconley/metering-spec/issues/4)
+**Issue:** [#4 Bundle multiple observations in single MeterRecord for atomicity](https://github.com/chrisconley/metron/issues/4)
 **Strategy:** Planned Refactoring (Add, Migrate, Remove)
 
 ---
@@ -429,7 +429,7 @@ Migration is complete when:
 
 ## References
 
-- **Issue:** [#4](https://github.com/chrisconley/metering-spec/issues/4)
+- **Issue:** [#4](https://github.com/chrisconley/metron/issues/4)
 - **Design analysis:** `design/references/meterrecord-atomicity-analysis.md`
 - **ADR:** `design/observation-temporal-context.md`
 - **Pattern guide:** `/Users/chris/.claude/skills/refactoring-sequencer/add-migrate-remove-guide.md`

--- a/arch/work/observation-domain-layer-migration-plan.md
+++ b/arch/work/observation-domain-layer-migration-plan.md
@@ -186,7 +186,7 @@ package internal
 
 import (
 	"fmt"
-	"metering-spec/specs"
+	"metron/specs"
 	"time"
 )
 
@@ -810,11 +810,11 @@ To eliminate unbundling would require redesigning aggregation to iterate over Ob
 ### Test Coverage
 
 All tests passing throughout migration:
-- `metering-spec/benchmarks` ✓
-- `metering-spec/internal` ✓
-- `metering-spec/internal/examples` ✓
-- `metering-spec/internal/infra` ✓
-- `metering-spec/specs` ✓
+- `metron/benchmarks` ✓
+- `metron/internal` ✓
+- `metron/internal/examples` ✓
+- `metron/internal/infra` ✓
+- `metron/specs` ✓
 
 ### Success Criteria Met
 

--- a/benchmarks/eventpayload_test.go
+++ b/benchmarks/eventpayload_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"metering-spec/specs"
+	"github.com/chrisconley/metron/specs"
 )
 
 // Benchmark EventPayloadSpec with minimal data (empty strings)

--- a/benchmarks/meterreading_test.go
+++ b/benchmarks/meterreading_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"metering-spec/specs"
+	"github.com/chrisconley/metron/specs"
 )
 
 // Benchmark MeterReadingSpec with minimal data

--- a/benchmarks/meterrecord_test.go
+++ b/benchmarks/meterrecord_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"metering-spec/specs"
+	"github.com/chrisconley/metron/specs"
 )
 
 // Benchmark MeterRecordSpec with minimal data

--- a/benchmarks/sizing_calculator_test.go
+++ b/benchmarks/sizing_calculator_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 	"unsafe"
 
-	"metering-spec/specs"
+	"github.com/chrisconley/metron/specs"
 )
 
 // SizeBreakdown provides size estimates for different contexts

--- a/design/observation-temporal-context.md
+++ b/design/observation-temporal-context.md
@@ -485,9 +485,9 @@ reading := MeterReadingSpec{
 
 ### Internal Documentation
 - `design/references/ubiquitous-language.md` - Comprehensive domain terminology definitions
-- `metering-spec/docs/time-spanning-events.md` - Temporal patterns for events
-- `metering-spec/docs/aggregation-types.md` - Counter vs gauge operations
-- `metering-spec/docs/observability-vs-metering.md` - Industry patterns and differences
+- `metron/docs/time-spanning-events.md` - Temporal patterns for events
+- `metron/docs/aggregation-types.md` - Counter vs gauge operations
+- `metron/docs/observability-vs-metering.md` - Industry patterns and differences
 - `arch/reference/chris-design-principles.md` - Design principles applied
 
 ### Discussion

--- a/design/references/event-sizing-and-cost-analysis.md
+++ b/design/references/event-sizing-and-cost-analysis.md
@@ -348,7 +348,7 @@ CREATE TABLE events (
 
 ## Practical Size Calculation: EventPayloadSpec
 
-From `metering-spec/specs/eventpayload.go`:
+From `metron/specs/eventpayload.go`:
 
 ```go
 type EventPayloadSpec struct {
@@ -1481,9 +1481,9 @@ The cost analysis shows that **engineering time spent on premature optimization*
 - [AWS Timestream Pricing](https://aws.amazon.com/timestream/pricing/)
 
 ### Internal Documentation
-- `metering-spec/docs/references/observability-vs-metering.md` - Observability vs metering patterns
-- `metering-spec/specs/eventpayload.go` - Event payload specification
-- `metering-spec/internal/examples/inflightpostflight_README.md` - Aggregation architecture
+- `metron/docs/references/observability-vs-metering.md` - Observability vs metering patterns
+- `metron/specs/eventpayload.go` - Event payload specification
+- `metron/internal/examples/inflightpostflight_README.md` - Aggregation architecture
 
 ---
 

--- a/design/references/meterrecord-atomicity-analysis.md
+++ b/design/references/meterrecord-atomicity-analysis.md
@@ -354,7 +354,7 @@ Replay attempt 2:
 
 ### Current Implementation Shows Atomicity Already Broken
 
-From `/Users/chris/workspace/meters/metering-spec/internal/examples/inflightpostflight_test.go:96-107`:
+From `/Users/chris/workspace/meters/metron/internal/examples/inflightpostflight_test.go:96-107`:
 
 ```go
 records, err := internal.Meter(payload, config)
@@ -380,7 +380,7 @@ for _, record := range records {
 
 ### Documentation Says "Multiple Records from One Event"
 
-From `/Users/chris/workspace/meters/metering-spec/specs/meterrecord.go:11-12`:
+From `/Users/chris/workspace/meters/metron/specs/meterrecord.go:11-12`:
 
 > "One event payload can produce multiple meter records when the metering configuration extracts multiple measurements from the same event."
 
@@ -710,10 +710,10 @@ bus.Publish(MeterRecordEvent{Record: record})  // Single publish
 
 ### Internal
 - `/Users/chris/workspace/meters/arch/reference/chris-design-principles.md` - Design principles applied
-- `/Users/chris/workspace/meters/metering-spec/specs/meterrecord.go` - Current spec
-- `/Users/chris/workspace/meters/metering-spec/internal/metering.go` - Meter() implementation
-- `/Users/chris/workspace/meters/metering-spec/internal/aggregation.go` - Aggregate() implementation
-- `/Users/chris/workspace/meters/metering-spec/internal/examples/inflightpostflight_test.go` - Publishing pattern
+- `/Users/chris/workspace/meters/metron/specs/meterrecord.go` - Current spec
+- `/Users/chris/workspace/meters/metron/internal/metering.go` - Meter() implementation
+- `/Users/chris/workspace/meters/metron/internal/aggregation.go` - Aggregate() implementation
+- `/Users/chris/workspace/meters/metron/internal/examples/inflightpostflight_test.go` - Publishing pattern
 
 ### Industry Patterns
 - Double-entry accounting: Transaction header + line items pattern

--- a/design/references/observability-vs-metering.md
+++ b/design/references/observability-vs-metering.md
@@ -191,7 +191,7 @@ Algorithm:
 
 **Correct answer: 12.32 seats** (not 12.5)
 
-### metering-spec's Approach
+### metron's Approach
 
 The [`Aggregate`](../../specs/aggregate.go) function signature captures this requirement:
 
@@ -269,11 +269,11 @@ type Aggregate func(
 
 **Adopt:** Explicit distinction between counters and gauges
 
-**metering-spec aggregation types** (from [`AggregateConfigSpec`](../../specs/aggregate.go)):
+**metron aggregation types** (from [`AggregateConfigSpec`](../../specs/aggregate.go)):
 - Counter aggregations: `sum`, `max`, `min`, `latest`
 - Gauge aggregations: `time-weighted-avg`, `max`, `min`, `latest`
 
-Aggregation names encode the semantic operation (not just implementation), mirroring OpenTelemetry's Counter vs UpDownCounter distinction. See [issue #5](https://github.com/chrisconley/potential-telegram/issues/5) for a proposed change to make counter vs gauge intent explicit in the aggregation name itself (e.g., `sum-events` vs `peak-state`).
+Aggregation names encode the semantic operation (not just implementation), mirroring OpenTelemetry's Counter vs UpDownCounter distinction. See [issue #5](https://github.com/chrisconley/metron/issues/5) for a proposed change to make counter vs gauge intent explicit in the aggregation name itself (e.g., `sum-events` vs `peak-state`).
 
 ### ✅ 2. Dimensional/Label Model
 
@@ -297,7 +297,7 @@ Aggregation names encode the semantic operation (not just implementation), mirro
 - Common attributes: `service.name`, `http.method`, `db.system`
 - Units in metadata, not names
 
-**metering-spec mapping:**
+**metron mapping:**
 - Quantities as decimal strings with explicit unit on each [`ObservationSpec`](../../specs/observation.go)
 - Per-meter schemas: [`MeteringConfigSpec`](../../specs/meteringconfig.go) with `ObservationExtractionSpec`
 - `EventPayload.Properties` → extracted observations + remaining dimensions
@@ -463,7 +463,7 @@ All these systems provide **higher-level products** (billing platforms) rather t
 2. **Time-weighted averages are critical**
    - Observability: `avg_over_time()` is arithmetic mean (not time-weighted)
    - Metering: Must use step interpolation for gauge aggregations
-   - metering-spec's `time-weighted-avg` is correct; most observability systems are not
+   - metron's `time-weighted-avg` is correct; most observability systems are not
 
 3. **Adopt useful patterns**
    - Metric type taxonomy (counter vs gauge)
@@ -522,7 +522,7 @@ All these systems provide **higher-level products** (billing platforms) rather t
 - [UniBee](https://unibee.dev/)
 - [TechCrunch: OpenMeter makes it easier for companies to track usage-based billing](https://techcrunch.com/2024/03/12/openmeter-makes-it-easier-for-companies-to-track-usage-based-billing/)
 
-### metering-spec
+### metron
 
 - [`specs/aggregate.go`](../../specs/aggregate.go) - Aggregation types and time-weighted average interface
 - [`specs/observation.go`](../../specs/observation.go) - Observation spec with decimal string quantities

--- a/docs/documentation-roadmap.md
+++ b/docs/documentation-roadmap.md
@@ -16,7 +16,7 @@ This document outlines the documentation strategy to make this a top-tier open s
 These are blocking adoption. Without them, users can't get started.
 
 #### 1. README.md (20 minutes, critical)
-**Location:** Root of metering-spec/
+**Location:** Root of metron/
 **Purpose:** Landing page that answers "what is this and why should I care?"
 
 **Must include:**
@@ -60,7 +60,7 @@ With brief explanation of each stage. ASCII art or Mermaid diagram acceptable.
 **Target audience:** Architects evaluating the spec
 
 #### 4. LICENSE (5 minutes, legally required)
-**Location:** Root of metering-spec/
+**Location:** Root of metron/
 **Purpose:** Legal clarity for open source usage
 
 **Recommendation:** MIT or Apache 2.0 (most permissive, common for specs)
@@ -133,7 +133,7 @@ These enable developers to use the spec correctly.
 These enable community contributions and evolution.
 
 #### 8. CONTRIBUTING.md (30 minutes)
-**Location:** Root of metering-spec/
+**Location:** Root of metron/
 **Purpose:** How to contribute to the spec
 
 **Should cover:**
@@ -186,7 +186,7 @@ These enable community contributions and evolution.
 - Precision handling (Decimal libraries)
 
 #### 12. CHANGELOG.md (ongoing)
-**Location:** Root of metering-spec/
+**Location:** Root of metron/
 **Purpose:** Track version history
 
 **Start when:** First versioned release (v0.1.0)

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -1,7 +1,7 @@
 # Open Issues Analysis
 
 **Analysis Date:** 2026-01-28 (Updated)
-**Repository:** metering-spec
+**Repository:** metron
 **Total Open Issues:** 4 (1 closed, 1 in PR review)
 
 ---

--- a/docs/issues/issue-01-observation-aggregation-types.md
+++ b/docs/issues/issue-01-observation-aggregation-types.md
@@ -1,6 +1,6 @@
 # Issue #1: Separate Observation and Aggregation types with temporal context
 
-**GitHub Issue:** https://github.com/chrisconley/potential-telegram/issues/1
+**GitHub Issue:** https://github.com/chrisconley/metron/issues/1
 **Autonomy Rating:** 85/100
 **Confidence Level:** High
 **Status:** Ready for implementation

--- a/docs/issues/issue-03-sizing-benchmarks.md
+++ b/docs/issues/issue-03-sizing-benchmarks.md
@@ -298,7 +298,7 @@ $ go test ./benchmarks/ -v -short
 --- PASS: TestScaleCalculations (0.00s)
 
 PASS
-ok  	metering-spec/benchmarks	0.221s
+ok  	metron/benchmarks	0.221s
 ```
 
 ---

--- a/docs/tmp/oss-research.md
+++ b/docs/tmp/oss-research.md
@@ -1,0 +1,237 @@
+# OSS README & Marketing Research — 2026-04-16
+
+Research on making open source projects successful, with specific focus on README best practices, developer adoption patterns, and competitive positioning for freetown (three-ledger accounting library).
+
+---
+
+## 1. What Developers Actually Do (Survey Data)
+
+### Catchy Agency Survey (202 developers, All Things Open 2025)
+- **73% want hands-on experience within minutes** — quickstart matters more than pitch
+- **Documentation is #1 trust signal (34.2%)** AND #1 abandonment trigger (17.3%) — single highest-leverage surface
+- **26.2% abandon if project looks unmaintained** — visible activity signals matter independent of code quality
+- **12.4% influenced by well-known users** — social proof works
+- One-command install or <5 min setup is the benchmark
+
+### GitHub Open Source Survey (5,500 respondents, 2017)
+- **72% always seek out open source options** when evaluating tools
+- **93% complained docs are incomplete or outdated** — #1 annoyance
+- **86% said security was extremely/very important**
+- **88% said stability was extremely important**
+- **67% said license is a determinant** when deciding to contribute
+
+### Time to First Hello World (TTFHW)
+- Measures time from first encounter to first working example
+- Low TTFHW correlates with higher retention and conversion
+- High TTFHW signals confusing docs, complex setup, or missing sandbox environments
+
+### Redpoint Ventures Data (80 developer tool companies)
+- Median stars at Seed: 2,850 / at Series A: 4,980
+- Average MoM star growth: 7.9%
+- Median contributors at Seed: 25 / at Series A: 50
+- "We view early-stage open source companies like social networks — community momentum takes precedence over revenue"
+
+---
+
+## 2. README Structure Consensus
+
+Across Tom Preston-Werner (README-driven development), makeareadme.com, Dan Bader's guide, awesome-readme, and the exemplar analysis:
+
+1. Project name + **one-line description that names the problem**
+2. Badges (build status, version, license)
+3. Hero image / animated GIF / screenshot
+4. Quick-start / installation (copyable code block)
+5. Usage examples (progressive: simple → realistic → advanced)
+6. Features
+7. API / configuration reference
+8. Contributing guide
+9. License
+10. Credits / acknowledgments
+
+### "Steal These Patterns" Checklist (from exemplar repos)
+- **Progression:** hello world → realistic → advanced composition (clear prerequisites)
+- **One folder per use-case:** each example runnable in isolation (README, config, expected output)
+- **Cross-links:** each recipe links back to primitives it uses; primitives link forward to recipes
+- **Testing:** examples are CI-verified (executed, compiled, or snapshot-tested)
+- **Consistency:** same naming conventions, same structure, same "shape" across examples
+
+---
+
+## 3. Advice from OSS Founders
+
+### Tom Preston-Werner (GitHub) — README Driven Development
+- "Write your README first. Before you write any code or tests or behaviors or stories or ANYTHING."
+- "A perfect implementation of the wrong specification is worthless. A beautifully crafted library with no documentation is also nearly worthless."
+- The README is "the single most important document in your codebase."
+- Writing it retroactively is "an absolute drag" — write it when excitement is highest.
+
+### Mitchell Hashimoto (HashiCorp/Terraform)
+- **Performance-based marketing**: Set up timers showing how fast HashiCorp shipped support for new cloud features vs. the clouds themselves. Directly countered the #1 objection.
+- Founders must personally understand the GTM motion before scaling it.
+- Community onboarding matters as much as employee onboarding.
+- "While Armon onboarded every employee, Mitchell onboarded the community."
+
+### Guillermo Rauch (Vercel/Next.js)
+- **"Be humble in early language"** — don't claim category leadership before earning it. Be specific about what you solve.
+- Start with a framework/tool, not a product. The commercial product comes later.
+- **Narrow scope ruthlessly** — PMF came when they narrowed to "the best React experience."
+- Learn from your most-loved feature, not your product vision.
+
+### Lago — How They Got First 1000 Stars
+- Published 2 articles/week consistently
+- Spent as much time distributing content as producing it
+- Out of ~60 articles, only 3-4 got traction on HN — persistence despite low hit rate
+- 6 months to 1,000 stars, then only 14 days to 1,500 (compounding)
+- Every self-hosted signup triggered a welcome email inviting users to star the repo
+
+### PHPStan — 0 to 1,000 Stars in Three Months
+- "Start with implementing the core idea where the value lies"
+- "Release the first version as soon as it's useful. Don't wait for it to be perfect."
+- "Without marketing, even the best projects would starve."
+
+### ToolJet — Zero to 10,000 Stars
+- Launched on Product Hunt first, then HN a few hours later
+- **Ported server from Ruby to JavaScript** because two languages was a contributor barrier
+- Regular blog posts about technology and best practices attracted both traffic and stars
+
+---
+
+## 4. Launch Platform Timing
+- **Hacker News:** 8:00-10:00 AM PT, Tuesday-Thursday
+- **Product Hunt:** start at 12:01 AM PT for full 24-hour voting cycle
+- **Reddit:** ~30 minutes after HN post (stagger to manage feedback)
+- Respond to comments within 2 hours — boosts visibility in algorithms
+- For libraries/CLI tools, HN and Reddit outperform Product Hunt. For products with a UI, Product Hunt is stronger.
+
+---
+
+## 5. Competitive Landscape: Billing/Accounting OSS
+
+### Billing Platforms (full applications, not libraries)
+
+| Project | One-liner | README strength | README weakness |
+|---------|-----------|-----------------|-----------------|
+| **Lago** | "The AI-native billing platform" | Social proof first (customer logos), features scannable, clear cloud vs self-hosted | "AI-native" rebrand obscures what it does |
+| **Kill Bill** | "Open-Source Subscription Billing & Payments Platform" | 15+ year track record, enterprise credibility | Corporate/vague, no code, no teaching |
+| **Flexprice** | "Monetization Infrastructure Built for AI Native Companies" | Sharpest problem articulation — names 4 explicit pain points | New/unproven, "AI Native" trend-chasing |
+| **OpenMeter** | "Open-source metering and billing platform" | Architecture section is a differentiator, SDK table clean | "AI, agentic and DevTool" feels like keyword stuffing |
+| **Lotus** (defunct) | "Pricing & Packaging Infrastructure For Any Business Model" | Best problem framing in the space — named the business problem | Tech stack details too prominent |
+
+### Fintech Ledger Infrastructure (closest architectural comparables)
+
+| Project | One-liner | README strength | README weakness |
+|---------|-----------|-----------------|-----------------|
+| **TigerBeetle** | "The financial transactions database" | Boldest positioning ("next 30 years"), working REPL immediately | Cryptically minimal — won't learn what it is from README |
+| **Formance Ledger** | "A programmable financial core ledger" | Use-case-driven positioning, numscript DSL differentiator | Too broad, assumes double-entry knowledge |
+| **Blnk Finance** | "Open-Source Financial Ledger for Developers" | "Fast without compromising compliance and correctness" — clean tension | Very thin README, no code examples |
+
+### Accounting Libraries (closest category match)
+
+| Project | One-liner | README strength | README weakness |
+|---------|-----------|-----------------|-----------------|
+| **Medici** (Node.js) | "Double-entry accounting system for nodejs + mongoose" | Best technical README — teaches through code, performance section | No problem statement, no "why" |
+| **GoDBLedger** (Go) | "Make double entry bookkeeping transactions programmable" | Multiple integration paths (gRPC, CLI, files) | Server not library, messy/sprawling README |
+| **ACCCORE** (Go) | "A core accounting library made in golang" | Narrow focus (virtual currencies) | Barely a README, no code examples |
+| **DEB** (Go) | "Double-entry bookkeeping library" | — | Essentially no README, abandoned |
+
+### Plain Text Accounting
+
+| Project | One-liner | Notable |
+|---------|-----------|---------|
+| **hledger** | "Robust, friendly, fast, plain text accounting" | "Any countable commodity" framing is broad and interesting |
+| **Beancount** | "Double-Entry Accounting from Text Files" | "Largely does away with credits and debits" — opposite design choice from freetown |
+
+---
+
+## 6. Positioning Analysis
+
+### The gap freetown occupies
+
+Nobody occupies "accounting library for monetization." The landscape splits cleanly:
+- **Billing platforms** (Lago, Kill Bill, OpenMeter, Flexprice) — full applications with metering, invoicing, payment orchestration
+- **Fintech ledgers** (TigerBeetle, Formance, Blnk) — infrastructure for moving money, focused on performance/safety
+- **Accounting libraries** (Medici, GoDBLedger, ACCCORE) — generic double-entry bookkeeping, no monetization domain knowledge
+- **Personal accounting** (hledger, Beancount) — individual finance, text files
+
+Freetown is a **domain-aware accounting library** — you embed it, not deploy it. This is an unclaimed position.
+
+### The Go accounting library space is dead
+DEB, ACCCORE, go-accounting are all minimal/abandoned. GoDBLedger is active but it's a server, not a library. Freetown would be the only serious Go accounting library with active development.
+
+### "AI-native" is the current bandwagon
+Lago, OpenMeter, Flexprice, and Amberflo have all recently added "AI" to their positioning. Crowded and increasingly meaningless. Avoid this trap.
+
+### Nobody explains accounting well
+Medici comes closest by teaching through code. Beancount has real educational content. But most projects assume you know double-entry or don't care. The three-ledger model is genuinely novel and needs to be explained, not assumed.
+
+### Library vs. platform is the sharpest edge
+Every billing project is a platform you deploy. Every accounting library is domain-ignorant. Freetown is a *library* with *domain knowledge* — you embed it, you don't deploy it.
+
+---
+
+## 7. What the Current README Gets Wrong
+
+Against all of the above, the current freetown README:
+- **No problem statement** — jumps straight into "4-stage pipeline" architecture
+- **No "who is this for"** — reader can't self-select
+- **Internal jargon** (CreditService, JournalRepository, GL concepts) before explaining what it does
+- **No one-liner** that names the problem or value
+- **Import path is `stunning-octo-lamp`** — placeholder, not a real project identity
+- **"Coming soon" section** signals incompleteness before establishing value
+- **References internal docs** (ADRs, arch work) that a public visitor can't access
+
+---
+
+## 8. Best Patterns to Steal
+
+From the exemplar analysis, the patterns that best match freetown's position:
+
+1. **Flexprice's problem articulation** — name explicit pain points the developer recognizes
+2. **Medici's code-first teaching** — teach the three-ledger model through usage, not theory
+3. **Formance's use-case framing** — "if you're building X, this is for you"
+4. **Lago's social proof positioning** — once there are users, lead with them
+5. **TigerBeetle's ambition** — make a bold claim about what you're building toward (but only once you can back it up)
+
+### Anti-patterns to avoid
+- Corporate vagueness (Kill Bill)
+- Feature-dumping without explaining "why" (OpenMeter)
+- "We do everything" positioning (Lago's recent shift)
+- Trend-chasing taglines ("AI-native")
+- No problem statement (Medici, TigerBeetle, ACCCORE)
+- Assuming the reader already knows they need double-entry bookkeeping
+
+---
+
+## Sources
+
+### Surveys and Data
+- Catchy Agency: What 202 Open Source Developers Taught Us About Tool Adoption
+- GitHub Open Source Survey 2017 (opensourcesurvey.org/2017/)
+- Tidelift 2024 State of the Open Source Maintainer Report
+- Redpoint Ventures: How Many Stars Is Enough?
+
+### Guides and Frameworks
+- Tom Preston-Werner: Readme Driven Development (tom.preston-werner.com)
+- Dan Bader: How to Write a Great README (dbader.org)
+- makeareadme.com
+- awesome-readme (github.com/matiassingers/awesome-readme)
+- Adam Stacoviak: Top Ten Reasons I Won't Use Your OSS Project (Changelog)
+- TODO Group: Marketing Open Source Projects
+- GitHub Blog: Marketing for Maintainers
+- GitHub Open Source Guides: Finding Users (opensource.guide/finding-users/)
+
+### Founder Lessons
+- Mitchell Hashimoto lessons (antoinebuteau.com, Heavybit talk)
+- Guillermo Rauch / Vercel PMF (First Round Review)
+- Jeff Lawson / Twilio: Ask Your Developer
+
+### Case Studies
+- Lago: How We Got Our First 1000 GitHub Stars
+- ToolJet: Zero to 10,000 Stargazers
+- PHPStan: 0 to 1,000 Stars in Three Months
+- daily.dev: Step-by-Step Launch Guide
+
+### DX Metrics
+- APIscene: Time to Hello World and Developer LTV
+- Moesif: Developer Experience Metrics That Matter
+- Nordic APIs: Why Time to First Call Is a Vital API Metric

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -1,0 +1,97 @@
+// Hello-world for metron.
+//
+// Meters two gauge events (seat count at two points in time), then aggregates
+// them with time-weighted-avg over a 30-day window.
+//
+//	customer:acme-corp used 11.67 seats (time-weighted-avg) from 2024-01-01 to 2024-01-31
+//
+// Why 11.67? The customer had 10 seats for 20 days, then 15 seats for 10 days.
+// Time-weighted average: (10×20 + 15×10) / 30 = 11.666... → 11.67.
+// A naive mean of 10 and 15 would give 12.5 — but that ignores how long
+// each value was in effect.
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/cockroachdb/apd/v3"
+
+	"github.com/chrisconley/metron/internal"
+	"github.com/chrisconley/metron/specs"
+)
+
+func main() {
+	// Extract the "seats" property as an observation with unit "seats".
+	// Any other property (region, plan, etc.) would flow through as a dimension.
+	meteringConfig := specs.MeteringConfigSpec{
+		Observations: []specs.ObservationExtractionSpec{
+			{SourceProperty: "seats", Unit: "seats"},
+		},
+	}
+
+	// Two gauge events: 10 seats at Jan 1, then 15 seats at Jan 21.
+	events := []specs.EventPayloadSpec{
+		{
+			ID: "evt_1", Type: "subscription.gauge",
+			WorkspaceID: "acme-prod", UniverseID: "production",
+			Subject:    "customer:acme-corp",
+			Time:       time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			Properties: map[string]string{"seats": "10"},
+		},
+		{
+			ID: "evt_2", Type: "subscription.gauge",
+			WorkspaceID: "acme-prod", UniverseID: "production",
+			Subject:    "customer:acme-corp",
+			Time:       time.Date(2024, 1, 21, 0, 0, 0, 0, time.UTC),
+			Properties: map[string]string{"seats": "15"},
+		},
+	}
+
+	// Stage 1 — Meter: event → records.
+	var records []specs.MeterRecordSpec
+	for _, event := range events {
+		recs, err := internal.Meter(event, meteringConfig)
+		if err != nil {
+			log.Fatalf("meter: %v", err)
+		}
+		records = append(records, recs...)
+	}
+
+	// Stage 2 — Aggregate: records → one reading over the billing window.
+	aggregateConfig := specs.AggregateConfigSpec{
+		Aggregation: "time-weighted-avg",
+		Window: specs.TimeWindowSpec{
+			Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			End:   time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	reading, err := internal.Aggregate(records, nil, aggregateConfig)
+	if err != nil {
+		log.Fatalf("aggregate: %v", err)
+	}
+
+	// The underlying quantity is exact (11.666…); round to cents for display.
+	value := reading.ComputedValues[0]
+	fmt.Printf("%s used %s %s (%s) from %s to %s\n",
+		reading.Subject,
+		roundCents(value.Quantity),
+		value.Unit,
+		value.Aggregation,
+		reading.Window.Start.Format("2006-01-02"),
+		reading.Window.End.Format("2006-01-02"),
+	)
+}
+
+// roundCents rounds a decimal string to two places using apd (no floats).
+func roundCents(s string) string {
+	var parsed apd.Decimal
+	if _, _, err := parsed.SetString(s); err != nil {
+		return s
+	}
+	var rounded apd.Decimal
+	ctx := apd.BaseContext.WithPrecision(34)
+	_, _ = ctx.Quantize(&rounded, &parsed, -2)
+	return rounded.String()
+}

--- a/examples/hello/main_test.go
+++ b/examples/hello/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestHelloOutput runs the hello example exactly as the README instructs
+// and asserts the single output line. If anyone changes the API or the
+// math in a way that shifts the displayed number, this test breaks before
+// the README's claimed output can drift.
+func TestHelloOutput(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("go", "run", ".")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("go run .: %v\nstderr: %s", err, stderr.String())
+	}
+
+	got := strings.TrimRight(stdout.String(), "\n")
+	want := "customer:acme-corp used 11.67 seats (time-weighted-avg) from 2024-01-01 to 2024-01-31"
+	if got != want {
+		t.Errorf("README quick-start output drift\n got:  %q\n want: %q", got, want)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module metering-spec
+module github.com/chrisconley/metron
 
 go 1.25.0
 

--- a/internal/aggregation.go
+++ b/internal/aggregation.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	specs "metering-spec/specs"
+	specs "github.com/chrisconley/metron/specs"
 	"time"
 )
 

--- a/internal/aggregationconfig.go
+++ b/internal/aggregationconfig.go
@@ -2,7 +2,7 @@ package internal
 
 import (
 	"fmt"
-	specs "metering-spec/specs"
+	specs "github.com/chrisconley/metron/specs"
 )
 
 type AggregationConfig struct {

--- a/internal/eventpayload.go
+++ b/internal/eventpayload.go
@@ -2,7 +2,7 @@ package internal
 
 import (
 	"fmt"
-	specs "metering-spec/specs"
+	specs "github.com/chrisconley/metron/specs"
 	"time"
 )
 

--- a/internal/examples/inflightpostflight_README.md
+++ b/internal/examples/inflightpostflight_README.md
@@ -65,7 +65,7 @@ Both subscribe to the same raw `MeterRecorded` events but operate independently 
 ## Running the Example
 
 ```bash
-cd metering-spec/internal/examples
+cd metron/internal/examples
 go test -v -run TestHighThroughputMeteringPipeline
 ```
 

--- a/internal/examples/inflightpostflight_test.go
+++ b/internal/examples/inflightpostflight_test.go
@@ -2,9 +2,9 @@ package examples
 
 import (
 	"fmt"
-	"metering-spec/internal"
-	"metering-spec/internal/infra"
-	"metering-spec/specs"
+	"github.com/chrisconley/metron/internal"
+	"github.com/chrisconley/metron/internal/infra"
+	"github.com/chrisconley/metron/specs"
 	"testing"
 	"time"
 

--- a/internal/metering.go
+++ b/internal/metering.go
@@ -2,7 +2,7 @@ package internal
 
 import (
 	"fmt"
-	specs "metering-spec/specs"
+	specs "github.com/chrisconley/metron/specs"
 )
 
 // Meter implements specs.Meter.

--- a/internal/meteringconfig.go
+++ b/internal/meteringconfig.go
@@ -2,7 +2,7 @@ package internal
 
 import (
 	"fmt"
-	specs "metering-spec/specs"
+	specs "github.com/chrisconley/metron/specs"
 )
 
 type MeteringConfig struct {

--- a/internal/meteringconfig_test.go
+++ b/internal/meteringconfig_test.go
@@ -1,7 +1,7 @@
 package internal
 
 import (
-	"metering-spec/specs"
+	"github.com/chrisconley/metron/specs"
 	"testing"
 	"time"
 

--- a/internal/meterreading.go
+++ b/internal/meterreading.go
@@ -2,7 +2,7 @@ package internal
 
 import (
 	"fmt"
-	specs "metering-spec/specs"
+	specs "github.com/chrisconley/metron/specs"
 	"time"
 )
 

--- a/internal/meterreading_test.go
+++ b/internal/meterreading_test.go
@@ -1,7 +1,7 @@
 package internal
 
 import (
-	"metering-spec/specs"
+	"github.com/chrisconley/metron/specs"
 	"testing"
 	"time"
 

--- a/internal/meterrecord.go
+++ b/internal/meterrecord.go
@@ -2,7 +2,7 @@ package internal
 
 import (
 	"fmt"
-	specs "metering-spec/specs"
+	specs "github.com/chrisconley/metron/specs"
 	"time"
 )
 


### PR DESCRIPTION
## Summary
- Rewrites the README for developer adoption against OSS best-practice research (now checked in at `docs/tmp/oss-research.md`), pulling the Try-it section above the fold with one command, interpretable output, and inline source.
- Renames the module `metering-spec` → `github.com/chrisconley/metron` across Go code, imports, benchmarks, and all design/arch docs.
- Adds MIT LICENSE and a runnable `examples/hello/` that computes the 11.67 seats time-weighted-avg promised in the README opening, guarded by a CI test that asserts exact output so the README can't drift from the code.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] `go run ./examples/hello` prints `customer:acme-corp used 11.67 seats (time-weighted-avg) from 2024-01-01 to 2024-01-31`

🤖 Generated with [Claude Code](https://claude.com/claude-code)