### PR TITLE
Rework README: scope-fit framing, tighter quick-start, fit-qualifier sections

### DIFF
--- a/.github/workflows/test-docs-only.yml
+++ b/.github/workflows/test-docs-only.yml
@@ -1,0 +1,24 @@
+name: Test (docs-only)
+
+# Companion to test.yml. Produces a `test` status check for PRs whose changes
+# are entirely in paths ignored by test.yml, so the required `test` check on
+# main can be satisfied without running the Go test suite on docs-only PRs.
+#
+# Behavior by PR content:
+#   - Only ignored paths  → test.yml skipped, this workflow runs → `test` ✅
+#   - Only non-ignored    → test.yml runs, this workflow skipped  → `test` ✅/❌
+#   - Mixed               → both run, both must pass              → `test` ✅/❌
+
+on:
+  pull_request:
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - 'arch/**'
+      - 'design/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only changes — skipping Go test suite."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'arch/**'
+      - 'design/**'
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go test ./...

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Recurring failures in usage-based billing pipelines:
 
 - **[`specs/`](specs/)** — language-agnostic types using only Go primitives (`string`, `time.Time`, `map[string]string`). This is what you'd port to another language. Two function signatures live here: `Meter` and `Aggregate`.
 - **[`internal/`](internal/)** — Go reference implementation. Domain-driven (value objects, deterministic IDs, decimal arithmetic via [`cockroachdb/apd`](https://github.com/cockroachdb/apd)). Use it as a Go library, or as a working example when implementing the spec elsewhere.
-- **[`examples/hello/`](examples/hello/)** — runnable end-to-end example.
+- **[`examples/`](examples/)** — runnable end-to-end examples covering counter sum, time-weighted gauge, bundled observations (atomicity), conditional metering, and time-spanning observations. See [`examples/README.md`](examples/README.md) for the full index.
 - **[`design/`](design/)** — ADRs and reference material, including the [ubiquitous language](design/references/ubiquitous-language.md) and the [observability-vs-metering](design/references/observability-vs-metering.md) study.
 
 A spec without a reference implementation is hard to verify; a reference implementation without a spec is hard to port. This repo ships both, with the boundary made explicit so you can take only the part you need.
@@ -142,6 +142,10 @@ EventPayload  ── Meter ──▶  MeterRecord  ── Aggregate ──▶  M
 
 `Meter` and `Aggregate` are the only two operations. `Meter` is per-event and stateless. `Aggregate` is per-`(subject, unit, window)` and accepts an optional `lastBeforeWindow` record for time-weighted gauges, so a gauge whose state didn't change inside the window still aggregates correctly. Both produce deterministic IDs from their inputs, so replaying yields the same output.
 
+## Where it fits
+
+TODO
+
 ## Why this design
 
 **Observations carry temporal context.** Every observation has a `Window`. Instant for gauge readings (`Start == End`), spanning for activity over a period (`Start < End`). Time-spanning events ("8 compute-hours from 8pm to 4am") and instant gauges ("15 seats at 9:47am") are both first-class without special-casing.
@@ -226,7 +230,12 @@ internal/               Go reference implementation
   decimal.go            Decimal value object (apd-backed)
   ...
 
-examples/hello/         Runnable end-to-end example
+examples/               Runnable end-to-end examples — see examples/README.md
+  hello/                  time-weighted gauge (the README quick-start)
+  api-calls/              counter sum
+  llm-tokens/             bundled observations, atomicity
+  conditional-tier/       conditional metering with filters
+  compute-session/        time-spanning observations
 benchmarks/             Pipeline benchmarks
 docs/                   Walkthroughs, examples, FAQ
 design/                 ADRs and reference material

--- a/README.md
+++ b/README.md
@@ -1,192 +1,249 @@
 # metron
 
-Data contracts and a Go reference implementation for metering — the part of billing that answers "how much did each customer use?"
+A metering specification for usage-based billing systems, with a Go reference implementation. Defines the pipeline from raw events to billable readings: idempotent metering, time-weighted gauge aggregation, two-dimensional tenant isolation. No pricing engine, no invoicing, no payment orchestration.
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/chrisconley/metron.svg)](https://pkg.go.dev/github.com/chrisconley/metron)
 
 > [!WARNING]
-> Pre-1.0. The core pipeline works and is tested. The data contracts are actively evolving. Expect breaking changes.
+> **Pre-1.0.** The data model and the two core operations (`Meter`, `Aggregate`) are stable and exercised by the test suite, but field names and the wire format may still change before `v1.0.0`.
 
-That question is harder than it sounds. Your API emits events with a bag of properties — `input_tokens`, `output_tokens`, `model`, `region`. Some are quantities you bill for. Others are dimensions you filter by. Different event types need different extraction rules.
+## The problem
 
-Aggregation is where it gets interesting. Some customers are metered by total usage (sum), others by peak concurrent usage (max), others by time-weighted average seat count. If a customer had 10 seats for 20 days then 15 seats for 10 days, the time-weighted average is 11.67, not 12.5. Every number has to be exact: no floating-point drift in financial calculations.
+Recurring failures in usage-based billing pipelines:
 
-metron is a spec and a reference implementation, not a platform you deploy. It defines data shapes and pure functions for the metering pipeline — events in, billable quantities out — so you can run it on infrastructure you own, or reimplement it in another language.
+- **A seat-count gauge gets averaged as a flat arithmetic mean.** A customer held 10 seats for 25 days, then 15 for 5; you bill `(10 + 15) / 2 = 12.5` seat-months. The right number is `(10 × 25 + 15 × 5) / 30 ≈ 10.83`. Prometheus's `avg_over_time` does the wrong one — fine for dashboards, wrong for invoices.
+- **Replaying yesterday's metering creates duplicate charges.** A bugfix means re-running the pipeline; the rerun emits new record IDs and the same usage gets billed twice.
+- **A gauge that didn't change during the window looks like zero usage.** No "seat count changed" events arrived this month, so the aggregator emits zero instead of carrying state forward from the last reading.
+- **Test events hit the production billing pipeline.** A staging load test shares the same Kafka topic and the same `customer:cust_123` subject as production; a workspace boundary or a separate "universe" would have stopped it.
+- **Aggregations cross units.** One reading ends up summing `tokens` and `compute-hours` because the aggregator only keyed by subject, not by `(subject, unit)`.
 
-## Try it
+`metron` is the data model and pipeline spec that makes those failures structural rather than recurring. It is the typed boundary between raw events arriving and billable usage being computed — not a billing platform, not a usage-tracking SaaS, not a query engine.
 
-```bash
-git clone https://github.com/chrisconley/metron.git
-cd metron
-go run ./examples/hello
-```
+## What's in this repo
 
-```
-customer:acme-corp used 11.67 seats (time-weighted-avg) from 2024-01-01 to 2024-01-31
-```
+`metron` is structured as a **specification plus a reference implementation**:
 
-That's the 11.67 from above, end-to-end — two gauge events become one billable reading. The shape:
+- **[`specs/`](specs/)** — language-agnostic types using only Go primitives (`string`, `time.Time`, `map[string]string`). This is what you'd port to another language. Two function signatures live here: `Meter` and `Aggregate`.
+- **[`internal/`](internal/)** — Go reference implementation. Domain-driven (value objects, deterministic IDs, decimal arithmetic via [`cockroachdb/apd`](https://github.com/cockroachdb/apd)). Use it as a Go library, or as a working example when implementing the spec elsewhere.
+- **[`examples/hello/`](examples/hello/)** — runnable end-to-end example.
+- **[`design/`](design/)** — ADRs and reference material, including the [ubiquitous language](design/references/ubiquitous-language.md) and the [observability-vs-metering](design/references/observability-vs-metering.md) study.
 
-```go
-meteringConfig := specs.MeteringConfigSpec{
-    Observations: []specs.ObservationExtractionSpec{
-        {SourceProperty: "seats", Unit: "seats"},
-    },
-}
-
-events := []specs.EventPayloadSpec{
-    {Subject: "customer:acme-corp", Time: jan1,  Properties: map[string]string{"seats": "10"}},
-    {Subject: "customer:acme-corp", Time: jan21, Properties: map[string]string{"seats": "15"}},
-}
-
-// Stage 1 — Meter: each event → records.
-var records []specs.MeterRecordSpec
-for _, event := range events {
-    recs, _ := internal.Meter(event, meteringConfig)
-    records = append(records, recs...)
-}
-
-// Stage 2 — Aggregate: records → one reading over the billing window.
-reading, _ := internal.Aggregate(records, nil, specs.AggregateConfigSpec{
-    Aggregation: "time-weighted-avg",
-    Window:      specs.TimeWindowSpec{Start: jan1, End: feb1},
-})
-```
-
-Full source: [`examples/hello/main.go`](examples/hello/main.go). The output line above is asserted by a test, so it can't drift from the code.
-
-Going further:
-
-- [`docs/examples/basic-api-metering.md`](docs/examples/basic-api-metering.md) — step-through walkthrough with JSON examples.
-- [`internal/examples/`](internal/examples/) — production-style pipeline: 300 events through an event bus, multiple aggregators at different time scales, rating handler firing threshold alerts. Run it: `go test -v ./internal/examples/ -run TestHighThroughputMeteringPipeline`.
-
-## What the pipeline does
-
-A metering config plus an event stream produces billable readings. The pipeline runs in two stages: **Meter** (per event) extracts quantities and preserves dimensions; **Aggregate** (per window) combines records into a reading.
-
-```jsonc
-// In: an event with untyped properties
-{
-  "id": "evt_abc123",
-  "type": "llm.completion",
-  "subject": "customer:cust_123",
-  "time": "2024-01-15T10:30:00Z",
-  "properties": {
-    "input_tokens": "1250",
-    "output_tokens": "340",
-    "model": "gpt-4",
-    "region": "us-east"
-  }
-}
-
-// Out: a reading over a billing window
-{
-  "subject": "customer:cust_123",
-  "computedValues": [
-    { "quantity": "125000", "unit": "input-tokens", "aggregation": "sum" }
-  ],
-  "window": { "start": "2024-01-01T00:00:00Z", "end": "2024-02-01T00:00:00Z" },
-  "recordCount": 100
-}
-```
-
-Properties on events are `map[string]string`, not a typed schema. Different products emit different properties without coordinating schema changes. The metering config — not the event schema — decides what's extracted.
-
-The config separates **quantities** (extracted, aggregated, summed/maxed/averaged) from **dimensions** (preserved as-is, for grouping and filtering downstream). Filters route the same event into different units based on tier, region, or any other property: `request_count` becomes `premium-requests` or `standard-requests` depending on which filter matches.
-
-Each pipeline stage broken out in [`docs/examples/basic-api-metering.md`](docs/examples/basic-api-metering.md).
+A spec without a reference implementation is hard to verify; a reference implementation without a spec is hard to port. This repo ships both, with the boundary made explicit so you can take only the part you need.
 
 ## Scope
 
-metron handles the **quantity pipeline**: raw events in, billable quantities out. It stops at the boundary where quantities become money.
+**In scope:** the event-to-record-to-reading pipeline; observation extraction with optional filters; pass-through dimensions; counter and gauge aggregations (`sum`, `max`, `min`, `latest`, `time-weighted-avg`); deterministic record and reading IDs for idempotent processing; workspace and universe tenant isolation; arbitrary-precision decimal quantities serialized as strings; watermarking for incremental aggregation.
 
-**In scope:** observation extraction, unit assignment, dimensional filtering, time-windowed aggregation, multi-tenant isolation, exact decimal arithmetic.
+**Out of scope:** rate cards and pricing; invoicing, dunning, and payment orchestration; tax computation; subscription lifecycle; an HTTP or gRPC service; a persistence layer; a query language. `metron` answers "given these events and this config, what is this subject's usage over this window?" — and stops there.
 
-**Out of scope:** pricing, rating, tiered rates, overage charges, committed-use discounts, credits, rollover, proration across billing periods, invoicing, payments, revenue recognition.
+**Refused even in scope** — choices `metron` deliberately doesn't make:
 
-**metron does NOT:**
+- **No mutable records.** A `MeterRecord` is an immutable historical fact; corrections are new records, not edits.
+- **No implicit unit coercion in aggregations.** Records with different units don't combine. A reading is always per-`(subject, unit, window)`.
+- **No floating-point quantities.** Every quantity crosses language and storage boundaries as a decimal string.
+- **No sampling, downsampling, or expiration.** Auditable data is kept; that's an observability feature, not a billing one.
 
-- compute prices or apply rate cards
-- round numbers (rounding belongs at the pricing layer, where business rules live)
-- silently truncate or coerce types
-- depend on a database or persistence layer (records and readings are pure data; storage is your choice)
+## Install
 
-The boundary is intentional. Pricing logic depends on contract-level rules — "this customer gets a volume discount above 100k tokens," "roll unused credits into next month" — that change per customer, per negotiation. Those computations consume metering quantities as input but aren't metering themselves. Conflating the two makes both harder to change independently.
+```sh
+go get github.com/chrisconley/metron
+```
 
-The spec preserves temporal context on observations (instant events vs. time-spanning measurements like compute sessions) so downstream consumers have what they need for proration and period assignment. See [observation-temporal-context.md](design/observation-temporal-context.md).
+Requires Go 1.25 or later.
 
-## Who this is for
+## Hello world
 
-You're building a system where:
+Two seat-count readings — 10 seats on Jan 1, 15 seats on Jan 21 — billed as a 30-day time-weighted average:
 
-- customers are billed by what they use — API calls, tokens, compute hours, storage, seats, or any countable resource
-- usage events come from multiple sources with different schemas, and you need a consistent metering layer
-- aggregation isn't just sum — you need peak (max), time-weighted averages, or latest-value gauges
-- billing periods matter — usage windows into hourly, daily, or monthly buckets for invoicing
-- precision matters — you're doing financial math and can't tolerate floating-point drift
+```go
+package main
 
-If your billing is flat-rate-only, you don't need a metering pipeline.
+import (
+    "fmt"
+    "log"
+    "time"
 
-## Why not just...
+    "github.com/chrisconley/metron/internal"
+    "github.com/chrisconley/metron/specs"
+)
 
-- **... a metering platform like [Lago](https://github.com/getlago/lago), [OpenMeter](https://github.com/openmeterio/openmeter), or Stripe Billing?** Those are platforms you deploy or subscribe to. metron is a spec and a library you embed. Pick a platform if you want the whole metering+pricing stack as a vendor-managed thing. Pick metron if you want to own the pipeline and only need the quantity-layer logic.
-- **... shopspring/decimal or apd directly?** metron uses [cockroachdb/apd](https://github.com/cockroachdb/apd) internally, and you could absolutely build metering yourself on top of any decimal library. metron's value is the data shapes (events, configs, records, readings) and the windowing/aggregation logic, not the arithmetic.
-- **... int64 cents?** Fine for currency at a fixed scale. Metering produces values like 11.67 seats or 0.0023 GB-hours — quantities that aren't currency, don't have a fixed scale, and need more than two decimal places.
+func main() {
+    // Extract the "seats" property as an observation with unit "seats".
+    // Any other property (region, plan, etc.) flows through as a dimension.
+    meteringConfig := specs.MeteringConfigSpec{
+        Observations: []specs.ObservationExtractionSpec{
+            {SourceProperty: "seats", Unit: "seats"},
+        },
+    }
+
+    // Two gauge events: 10 seats on Jan 1, then 15 seats on Jan 21.
+    events := []specs.EventPayloadSpec{
+        {
+            ID: "evt_1", Type: "subscription.gauge",
+            WorkspaceID: "acme-prod", UniverseID: "production",
+            Subject:    "customer:acme-corp",
+            Time:       time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+            Properties: map[string]string{"seats": "10"},
+        },
+        {
+            ID: "evt_2", Type: "subscription.gauge",
+            WorkspaceID: "acme-prod", UniverseID: "production",
+            Subject:    "customer:acme-corp",
+            Time:       time.Date(2024, 1, 21, 0, 0, 0, 0, time.UTC),
+            Properties: map[string]string{"seats": "15"},
+        },
+    }
+
+    // Stage 1 — Meter: event → record.
+    var records []specs.MeterRecordSpec
+    for _, e := range events {
+        recs, err := internal.Meter(e, meteringConfig)
+        if err != nil {
+            log.Fatal(err)
+        }
+        records = append(records, recs...)
+    }
+
+    // Stage 2 — Aggregate: records → one reading over the billing window.
+    reading, err := internal.Aggregate(records, nil, specs.AggregateConfigSpec{
+        Aggregation: "time-weighted-avg",
+        Window: specs.TimeWindowSpec{
+            Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+            End:   time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC),
+        },
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    v := reading.ComputedValues[0]
+    fmt.Printf("%s: %s %s (%s)\n", reading.Subject, v.Quantity, v.Unit, v.Aggregation)
+    // customer:acme-corp: 11.66666666666666666666666666666667 seats (time-weighted-avg)
+}
+```
+
+The customer held 10 seats for 20 days and 15 seats for 10 days. The exact answer is `(10 × 20 + 15 × 10) / 30 = 11.666…`, which `time-weighted-avg` returns at full decimal precision; rounding to invoice cents happens at the display boundary in your decimal library of choice. A naive arithmetic mean of 10 and 15 would give 12.5 — a 7% over-bill that compounds across customers and months.
+
+The full source — including a small rounding helper — is in [`examples/hello/main.go`](examples/hello/main.go); `go run ./examples/hello` runs it.
+
+## Core idea: two operations, three types
+
+```
+EventPayload  ── Meter ──▶  MeterRecord  ── Aggregate ──▶  MeterReading
+(raw usage)   (+ config)    (typed usage     (+ config,       (one or more
+                            with one or       + window)        ComputedValues
+                            many                               over the window)
+                            Observations)
+```
+
+- **`EventPayload`** is the input boundary. A flexible `map[string]string` carries event-type-specific data: `tokens`, `endpoint`, `region`, whatever you publish.
+- **`MeterRecord`** is the typed result of metering. It carries one or more `Observation`s — each a `(quantity, unit, window)` triple where the window is instant `[T, T]` for gauges or spanning `[T1, T2]` for activity over a period — plus the dimensions that weren't extracted as observations.
+- **`MeterReading`** is the aggregated result over a billing window. It carries one or more `ComputedValue`s — each a `(quantity, unit, aggregation)` triple — so the strategy that produced the value is part of the value.
+
+`Meter` and `Aggregate` are the only two operations. `Meter` is per-event and stateless. `Aggregate` is per-`(subject, unit, window)` and accepts an optional `lastBeforeWindow` record for time-weighted gauges, so a gauge whose state didn't change inside the window still aggregates correctly. Both produce deterministic IDs from their inputs, so replaying yields the same output.
 
 ## Why this design
 
-**Configuration-driven, not code-driven.** Extraction rules, filters, units, and aggregation strategies are all configuration. New products and pricing models update a metering config; engineering doesn't touch the pipeline.
+**Observations carry temporal context.** Every observation has a `Window`. Instant for gauge readings (`Start == End`), spanning for activity over a period (`Start < End`). Time-spanning events ("8 compute-hours from 8pm to 4am") and instant gauges ("15 seats at 9:47am") are both first-class without special-casing.
 
-**Pricing-agnostic.** The same pipeline serves usage-based billing (token counts), seat-based pricing (time-weighted averages), hybrid models (both), and flat-rate-with-overage (commit thresholds). The metering layer produces quantities; what those cost is downstream.
+**One event, one record, possibly many observations.** An LLM completion event with `input_tokens` and `output_tokens` produces a single `MeterRecord` with two observations bundled inside it. They persist atomically — either both observations land or neither does — and the record's idempotency key is the source event ID. No partial double-billing.
 
-**One event, one record.** All observations from a single event bundle into one MeterRecord. Persistence is atomic — all observations save together or none do. No partial event data in the pipeline. See [meterrecord-atomicity-analysis.md](design/references/meterrecord-atomicity-analysis.md).
+**Aggregations carry their strategy.** `ComputedValue` is `(quantity, unit, aggregation)`, not just `(quantity, unit)`. A reading that says "12.5 seats" is incomplete; one that says "12.5 seats, time-weighted-avg" is auditable. Hierarchical aggregation needs this; so does dispute resolution.
 
-**No schema coordination.** Event properties are untyped strings. Teams add new properties to their events without coordinating across the metering system. The metering config — not the event schema — decides what gets extracted.
+**Two dimensions of isolation.** `WorkspaceID` is the operational boundary — regions, business units, tenants of your platform. `UniverseID` is the data namespace — production vs staging vs simulation. The same `customer:cust_123` in two universes is two distinct billing entities. The model collapses cleanly when you don't need it (`UniverseID = "production"` always) and gives you a real isolation layer when you do.
 
-**Replay-safe.** Pure functions with deterministic IDs. Reprocessing the same events with the same configuration produces identical records. No hidden state, no side effects, no order dependence.
+**Decimal strings for quantities.** A quantity is `"123.456"`, not `float64`. Floating-point representation drifts across languages, precision is implicit, and a metering pipeline that crosses Go, Python, and SQL needs the same value to be the same value at every hop. The reference implementation uses [`cockroachdb/apd`](https://github.com/cockroachdb/apd) internally and never exposes it.
 
-**Exact arithmetic.** All quantities are decimal strings (`"123.45"`, not `123.45`). No floating-point anywhere. The Go implementation uses [cockroachdb/apd](https://github.com/cockroachdb/apd) for arbitrary-precision decimal arithmetic.
+**Watermarking is a first-class field.** Every `MeterRecord` has a `MeteredAt` system timestamp distinct from the business `ObservedAt`. Aggregations track `MaxMeteredAt`, so a downstream system can ask "give me readings whose source records were all metered before T" and get a stable answer. Late-arriving events show up as new records with newer `MeteredAt`, not as silent edits to old ones.
 
-## Aggregation strategies
+**Deterministic IDs are computed, not generated.** A `MeterRecord` ID is derived from the source event ID; a `MeterReading` ID is derived from `(subject, unit, window, aggregation)`. Re-running the pipeline produces the same IDs. Idempotent ingestion is "insert if not exists," not "deduplicate after the fact."
 
-| Strategy | Use case | Example |
-|----------|----------|---------|
-| **sum** | Cumulative usage | Total API calls, tokens consumed |
-| **max** | Peak usage | Concurrent connections, queue depth |
-| **min** | Minimum in window | Lowest price, minimum inventory |
-| **latest** | Current state | Most recent gauge reading |
-| **time-weighted-avg** | Average over time | Seat count across a billing month |
+## Why not just…?
 
-Time-weighted average treats each observation as a step function. This matters when the value changes mid-period: 10 seats for 20 days then 15 seats for 10 days averages to 11.67, not 12.5 (which is what a naive mean of the two values would give). See [aggregation-types.md](design/aggregation-types.md).
+### Why not Prometheus or OpenTelemetry?
 
-## Multi-tenant isolation
+Observability systems are designed for operational data: sample loss is acceptable, retention is finite, and `avg_over_time` is arithmetic mean. Billing data is auditable: every event must be retained, every aggregation must be exact, and a seat-count gauge needs step-interpolated time weighting. Prometheus's docs say it directly:
 
-Events are scoped by two dimensions:
+> "If you need 100% accuracy, such as for per-request billing, Prometheus is not a good choice."
 
-- **Workspace** — operational boundary (US region, EU region, a business unit). Each workspace owns its event schemas and metering configs.
-- **Universe** — data namespace (production, test, staging, simulation). The same customer ID in different universes is a different billing entity.
+The taxonomy translates well — counter vs gauge, dimensions, cardinality concerns — but the storage and aggregation guarantees don't. Observability for monitoring; a metering spec for billing. The full mapping is in [`design/references/observability-vs-metering.md`](design/references/observability-vs-metering.md).
 
-You can run test data through the same pipeline as production without cross-contamination, or meter the same customer differently in different regions. See [workspace-universe-isolation.md](design/workspace-universe-isolation.md).
+### Why not [OpenMeter](https://github.com/openmeterio/openmeter), [Lago](https://github.com/getlago/lago), or [Kill Bill](https://github.com/killbill/killbill)?
 
-## Repository structure
+Those are full billing platforms — metering, pricing, invoicing, subscriptions, dunning, payment orchestration. `metron` is the data-model layer that sits underneath. If you want to operate a billing system, pick a platform. If you're building one — or you have an existing system and you want a portable, language-agnostic shape for the metering layer — `metron` is the size of one component inside that platform.
 
-The Go reference implementation lives in `internal/`. The portable data contracts — language-agnostic Go structs with JSON tags — live in `specs/`, designed to be re-implemented in any language.
+### Why not roll your own?
+
+Rolling your own metering is the default and a reasonable place to start. After a few iterations, the same pieces show up in every implementation: time-weighted aggregation, deterministic record IDs, watermarking, a way to keep test events from billing customers, a place to put dimensions. `metron` is that converged shape, with the design rationale traced in [`design/`](design/) so you can adapt it instead of re-deriving it.
+
+## How it compares
+
+**[OpenMeter](https://github.com/openmeterio/openmeter)** — Apache-2.0, Kafka-based real-time aggregation, AI/API-billing focus, ships with Stripe sync. The closest spiritual peer; OpenMeter is the deployable system, `metron` is the data model. Pick OpenMeter if you want to run metering as a service today; reach for the metron spec when you need a portable shape that isn't tied to a specific deployment.
+
+**[Lago](https://github.com/getlago/lago)** — open-source usage-based billing platform with subscription management. One layer above; Lago is what you'd build *with* a metering layer like this, plus pricing, invoicing, and payment.
+
+**[Kill Bill](https://github.com/killbill/killbill)** — long-running JVM billing platform. Same shape as Lago; broader scope, more mature in enterprise contexts.
+
+**[CloudEvents](https://github.com/cloudevents/spec)** — event envelope spec. Compatible. CloudEvents tells you how to wrap an event for transport; `metron` tells you how to turn an event into a meter record.
+
+**Prometheus / OpenTelemetry** — observability. See above.
+
+## Concepts at a glance
+
+| Term | What it is |
+|---|---|
+| `EventPayload` | Raw usage activity at the system boundary. Untyped properties map. |
+| `MeterRecord` | Typed result of metering. Carries `Observation`s and pass-through `Dimensions`. |
+| `MeterReading` | Aggregated result over a window. Carries one or more `ComputedValue`s. |
+| `Observation` | `(quantity, unit, window)`. Window is instant `[T, T]` or spanning `[T1, T2]`. |
+| `ComputedValue` | `(quantity, unit, aggregation)`. The aggregation strategy is part of the value. |
+| `Subject` | The billing entity, formatted `"type:id"` (e.g. `"customer:cust_123"`). |
+| `Workspace` | Operational boundary. Owns event schemas and metering configs. |
+| `Universe` | Data namespace within a workspace. Scopes subject identity. |
+| `Aggregation` | One of `sum`, `max`, `min`, `latest`, `time-weighted-avg`. |
+| `MeteringConfig` | What to extract from each event, with optional filters. |
+| `AggregateConfig` | Aggregation function + half-open `[Start, End)` window. |
+
+The full vocabulary, with the design rationale for each term, lives in [`design/references/ubiquitous-language.md`](design/references/ubiquitous-language.md).
+
+## Repository layout
 
 ```
-specs/           Data contracts (language-agnostic Go structs with JSON tags)
-internal/        Go reference implementation (Meter, Aggregate)
-  examples/      Production-style pipeline example
-examples/        Runnable quick-start example
-design/          Architecture decision records
-docs/examples/   Walkthrough guides
-benchmarks/      Performance tests
+specs/                  Language-agnostic spec (primitives only)
+  eventpayload.go       EventPayloadSpec
+  meterrecord.go        MeterRecordSpec
+  meterreading.go       MeterReadingSpec, TimeWindowSpec
+  observation.go        ObservationSpec, ComputedValueSpec
+  meteringconfig.go     MeteringConfigSpec, ObservationExtractionSpec, FilterSpec
+  aggregate.go          AggregateConfigSpec, Aggregate signature
+  meter.go              Meter signature
+
+internal/               Go reference implementation
+  metering.go           Meter — event → records
+  aggregation.go        Aggregate — records → reading
+  meterrecord.go        MeterRecord domain object
+  meterreading.go       MeterReading domain object
+  decimal.go            Decimal value object (apd-backed)
+  ...
+
+examples/hello/         Runnable end-to-end example
+benchmarks/             Pipeline benchmarks
+docs/                   Walkthroughs, examples, FAQ
+design/                 ADRs and reference material
 ```
 
-## Design notes
+## Development
 
-- [Observation temporal context](design/observation-temporal-context.md) — instant events vs. time-spanning measurements
-- [Aggregation types](design/aggregation-types.md) — design rationale for sum / max / min / latest / time-weighted-avg
-- [Workspace × universe isolation](design/workspace-universe-isolation.md) — why two dimensions, not one
-- [MeterRecord atomicity](design/references/meterrecord-atomicity-analysis.md) — one event, one record
+```sh
+go test ./...                      # unit + integration tests
+go run ./examples/hello            # run the hello-world example
+go test ./benchmarks/...           # benchmark suite
+```
+
+## Contributing
+
+Issues and PRs welcome. Spec changes should ground in a use case the reference implementation can demonstrate. Reference-implementation changes should keep the `specs/` layer dependency-free of `apd` or any other decimal library — that boundary is what makes the spec portable.
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 Data contracts and a Go reference implementation for metering — the part of billing that answers "how much did each customer use?"
 
+> [!WARNING]
 > Pre-1.0. The core pipeline works and is tested. The data contracts are actively evolving. Expect breaking changes.
 
-That question is harder than it sounds. Your API emits events with a bag of properties (`input_tokens`, `output_tokens`, `model`, `region`). Some are quantities you bill for. Others are dimensions you filter by. Different event types need different extraction rules.
+That question is harder than it sounds. Your API emits events with a bag of properties — `input_tokens`, `output_tokens`, `model`, `region`. Some are quantities you bill for. Others are dimensions you filter by. Different event types need different extraction rules.
 
-Then aggregation gets interesting. Some customers are metered by total usage (sum), others by peak concurrent usage (max), others by average seat count weighted across the billing period. If a customer had 10 seats for 20 days then 15 seats for 10 days, the time-weighted average is 11.67 — not 12.5. Every number has to be exact: no floating-point drift in financial calculations.
+Aggregation is where it gets interesting. Some customers are metered by total usage (sum), others by peak concurrent usage (max), others by time-weighted average seat count. If a customer had 10 seats for 20 days then 15 seats for 10 days, the time-weighted average is 11.67, not 12.5. Every number has to be exact: no floating-point drift in financial calculations.
 
-This is a spec and a reference implementation, not a platform you deploy. It defines data shapes and pure functions for the metering pipeline: take raw events in, get billable quantities out. You own the infrastructure.
+metron is a spec and a reference implementation, not a platform you deploy. It defines data shapes and pure functions for the metering pipeline — events in, billable quantities out — so you can run it on infrastructure you own, or reimplement it in another language.
 
 ## Try it
 
@@ -22,118 +23,47 @@ go run ./examples/hello
 customer:acme-corp used 11.67 seats (time-weighted-avg) from 2024-01-01 to 2024-01-31
 ```
 
-That's the 11.67 from above, computed end-to-end: two gauge events (10 seats at Jan 1, 15 seats at Jan 21) become one billable reading for January. The whole program is one file:
+That's the 11.67 from above, end-to-end — two gauge events become one billable reading. The shape:
 
 ```go
-package main
-
-import (
-	"fmt"
-	"log"
-	"time"
-
-	"github.com/cockroachdb/apd/v3"
-
-	"github.com/chrisconley/metron/internal"
-	"github.com/chrisconley/metron/specs"
-)
-
-func main() {
-	// Extract the "seats" property as an observation with unit "seats".
-	meteringConfig := specs.MeteringConfigSpec{
-		Observations: []specs.ObservationExtractionSpec{
-			{SourceProperty: "seats", Unit: "seats"},
-		},
-	}
-
-	// Two gauge events: 10 seats at Jan 1, then 15 seats at Jan 21.
-	events := []specs.EventPayloadSpec{
-		{
-			ID: "evt_1", Type: "subscription.gauge",
-			WorkspaceID: "acme-prod", UniverseID: "production",
-			Subject:    "customer:acme-corp",
-			Time:       time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-			Properties: map[string]string{"seats": "10"},
-		},
-		{
-			ID: "evt_2", Type: "subscription.gauge",
-			WorkspaceID: "acme-prod", UniverseID: "production",
-			Subject:    "customer:acme-corp",
-			Time:       time.Date(2024, 1, 21, 0, 0, 0, 0, time.UTC),
-			Properties: map[string]string{"seats": "15"},
-		},
-	}
-
-	// Stage 1 — Meter: event → records.
-	var records []specs.MeterRecordSpec
-	for _, event := range events {
-		recs, err := internal.Meter(event, meteringConfig)
-		if err != nil {
-			log.Fatalf("meter: %v", err)
-		}
-		records = append(records, recs...)
-	}
-
-	// Stage 2 — Aggregate: records → one reading over the billing window.
-	reading, err := internal.Aggregate(records, nil, specs.AggregateConfigSpec{
-		Aggregation: "time-weighted-avg",
-		Window: specs.TimeWindowSpec{
-			Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-			End:   time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC),
-		},
-	})
-	if err != nil {
-		log.Fatalf("aggregate: %v", err)
-	}
-
-	// The underlying quantity is exact (11.666…); round to cents for display.
-	value := reading.ComputedValues[0]
-	fmt.Printf("%s used %s %s (%s) from %s to %s\n",
-		reading.Subject, roundCents(value.Quantity), value.Unit, value.Aggregation,
-		reading.Window.Start.Format("2006-01-02"), reading.Window.End.Format("2006-01-02"),
-	)
+meteringConfig := specs.MeteringConfigSpec{
+    Observations: []specs.ObservationExtractionSpec{
+        {SourceProperty: "seats", Unit: "seats"},
+    },
 }
 
-func roundCents(s string) string {
-	var parsed, rounded apd.Decimal
-	parsed.SetString(s)
-	apd.BaseContext.WithPrecision(34).Quantize(&rounded, &parsed, -2)
-	return rounded.String()
+events := []specs.EventPayloadSpec{
+    {Subject: "customer:acme-corp", Time: jan1,  Properties: map[string]string{"seats": "10"}},
+    {Subject: "customer:acme-corp", Time: jan21, Properties: map[string]string{"seats": "15"}},
 }
+
+// Stage 1 — Meter: each event → records.
+var records []specs.MeterRecordSpec
+for _, event := range events {
+    recs, _ := internal.Meter(event, meteringConfig)
+    records = append(records, recs...)
+}
+
+// Stage 2 — Aggregate: records → one reading over the billing window.
+reading, _ := internal.Aggregate(records, nil, specs.AggregateConfigSpec{
+    Aggregation: "time-weighted-avg",
+    Window:      specs.TimeWindowSpec{Start: jan1, End: feb1},
+})
 ```
 
-Source: [`examples/hello/main.go`](examples/hello/main.go). The output line is asserted by a test, so it can't drift from the code.
+Full source: [`examples/hello/main.go`](examples/hello/main.go). The output line above is asserted by a test, so it can't drift from the code.
 
-### Going deeper
+Going further:
 
-- **[Basic API metering walkthrough](docs/examples/basic-api-metering.md)** — step through each pipeline stage with JSON examples.
-- **Production-style pipeline** — 300 events over 30 seconds through an event bus, multiple aggregators at different time scales, and a rating handler firing threshold alerts. Source: [`internal/examples/`](internal/examples/). Run it: `go test -v ./internal/examples/ -run TestHighThroughputMeteringPipeline`.
-
-The Go reference implementation lives in `internal/`. The portable data contracts — language-agnostic Go structs with JSON tags — live in `specs/`, designed to be re-implemented in any language.
-
-## Why this design
-
-**No code changes for new billing models.** Extraction rules, filters, units, and aggregation strategies are all configuration. When a new product launches or a pricing model changes, you update a metering config — engineering doesn't touch the pipeline.
-
-**Any pricing model.** Usage-based billing needs token counts. Seat-based pricing needs time-weighted seat averages. Hybrid models need both. Even flat-rate plans with overage clauses need to know when a customer exceeds their commitment. The metering layer produces quantities; it doesn't know or care which pricing model consumes them.
-
-**One event, one record.** All observations extracted from a single event are bundled in one MeterRecord. Persistence is atomic — all observations save together or none do. No partial event data in the pipeline. See [meterrecord-atomicity-analysis.md](design/references/meterrecord-atomicity-analysis.md) for the full design rationale.
-
-**No schema coordination.** Event properties are untyped strings. Teams add new properties to their events without coordinating across the metering system. The metering config — not the event schema — decides what gets extracted.
-
-**Replay-safe.** Pure functions with deterministic IDs. Reprocessing the same events with the same configuration produces identical records. No hidden state, no side effects, no order dependence.
-
-**Exact arithmetic.** All quantities are decimal strings (`"123.45"`, not `123.45`). No floating-point anywhere. The Go implementation uses [`cockroachdb/apd`](https://github.com/cockroachdb/apd) for arbitrary-precision decimal arithmetic.
-
-**Test and production in one pipeline.** Workspace × universe scoping isolates data without separate infrastructure. Run test events through the same pipeline as production without cross-contamination.
+- [`docs/examples/basic-api-metering.md`](docs/examples/basic-api-metering.md) — step-through walkthrough with JSON examples.
+- [`internal/examples/`](internal/examples/) — production-style pipeline: 300 events through an event bus, multiple aggregators at different time scales, rating handler firing threshold alerts. Run it: `go test -v ./internal/examples/ -run TestHighThroughputMeteringPipeline`.
 
 ## What the pipeline does
 
-Events arrive from your application with a bag of untyped string properties. The pipeline transforms them into billable quantities through a series of configurable steps.
+A metering config plus an event stream produces billable readings. The pipeline runs in two stages: **Meter** (per event) extracts quantities and preserves dimensions; **Aggregate** (per window) combines records into a reading.
 
-### 1. Accept events with untyped properties
-
-```json
+```jsonc
+// In: an event with untyped properties
 {
   "id": "evt_abc123",
   "type": "llm.completion",
@@ -146,50 +76,8 @@ Events arrive from your application with a bag of untyped string properties. The
     "region": "us-east"
   }
 }
-```
 
-Properties are `map[string]string`, not a typed schema. This is deliberate. Different products emit different properties without coordinating schema changes across the metering system. The metering config decides what matters — not the event schema.
-
-### 2. Filter by property values
-
-Not every event produces the same observations. A metering config can include filters that match on property values:
-
-```json
-{
-  "sourceProperty": "request_count",
-  "unit": "premium-requests",
-  "filter": { "property": "tier", "equals": "premium" }
-}
-```
-
-This lets you meter the same event type differently based on customer tier, region, product variant, or any other property — through configuration, not code branches.
-
-### 3. Extract quantities and assign units
-
-The config specifies which properties are quantities and what unit to assign:
-
-```json
-{
-  "observations": [
-    { "sourceProperty": "input_tokens", "unit": "input-tokens" },
-    { "sourceProperty": "output_tokens", "unit": "output-tokens" }
-  ]
-}
-```
-
-Each extraction parses the string value into an exact decimal, pairs it with a unit, and timestamps it with the event's time. The same source property can map to different units depending on which filter matched — `request_count` becomes `premium-requests` or `standard-requests` based on the customer's tier.
-
-### 4. Preserve remaining properties as dimensions
-
-Properties not extracted as quantities (`model`, `region` in the example above) become **dimensions** on the metered record — preserved for filtering and grouping downstream ("show me token usage broken down by model and region").
-
-The distinction matters: quantities get aggregated (summed, maxed, averaged). Dimensions get preserved (for grouping, filtering, reporting). You don't have to decide up front which properties you'll want to group by later — everything that isn't a quantity is kept.
-
-### 5. Aggregate over billing windows
-
-Observations are combined over a time window using a configured [aggregation strategy](#aggregation-strategies):
-
-```json
+// Out: a reading over a billing window
 {
   "subject": "customer:cust_123",
   "computedValues": [
@@ -200,29 +88,62 @@ Observations are combined over a time window using a configured [aggregation str
 }
 ```
 
-This is where metron's job ends. The reading says "customer cust_123 used 125,000 input-tokens this month." What that costs is a pricing/rating concern handled elsewhere.
+Properties on events are `map[string]string`, not a typed schema. Different products emit different properties without coordinating schema changes. The metering config — not the event schema — decides what's extracted.
 
-## Who this is for
+The config separates **quantities** (extracted, aggregated, summed/maxed/averaged) from **dimensions** (preserved as-is, for grouping and filtering downstream). Filters route the same event into different units based on tier, region, or any other property: `request_count` becomes `premium-requests` or `standard-requests` depending on which filter matches.
 
-You're building a system where:
-
-- **Customers are billed based on what they use** — API calls, tokens, compute hours, storage, seats, or any countable resource
-- **Usage events come from multiple sources** with different schemas, and you need a consistent metering layer
-- **Aggregation isn't just "sum"** — you need peak usage (max), time-weighted averages (seat count over a month), or latest-value gauges
-- **Billing periods matter** — you need to window usage into hourly, daily, or monthly buckets for invoicing
-- **Precision matters** — you're doing financial math and can't tolerate floating-point drift
+Each pipeline stage broken out in [`docs/examples/basic-api-metering.md`](docs/examples/basic-api-metering.md).
 
 ## Scope
 
-Metering-spec handles the **quantity pipeline**: raw events in, billable quantities out. It stops at the boundary where quantities become money.
+metron handles the **quantity pipeline**: raw events in, billable quantities out. It stops at the boundary where quantities become money.
 
 **In scope:** observation extraction, unit assignment, dimensional filtering, time-windowed aggregation, multi-tenant isolation, exact decimal arithmetic.
 
 **Out of scope:** pricing, rating, tiered rates, overage charges, committed-use discounts, credits, rollover, proration across billing periods, invoicing, payments, revenue recognition.
 
-The boundary is intentional. Pricing logic depends on business rules that change per customer, per contract, per negotiation — "this customer gets a volume discount above 100k tokens" or "roll unused credits into next month." Those computations take metering quantities as *input* but aren't metering themselves. Conflating the two makes both harder to change independently.
+**metron does NOT:**
 
-The spec does preserve temporal context on observations (both instant events and time-spanning measurements like compute sessions) so that downstream consumers have the information they need for proration and period assignment. See [observation-temporal-context.md](design/observation-temporal-context.md) for the design rationale.
+- compute prices or apply rate cards
+- round numbers (rounding belongs at the pricing layer, where business rules live)
+- silently truncate or coerce types
+- depend on a database or persistence layer (records and readings are pure data; storage is your choice)
+
+The boundary is intentional. Pricing logic depends on contract-level rules — "this customer gets a volume discount above 100k tokens," "roll unused credits into next month" — that change per customer, per negotiation. Those computations consume metering quantities as input but aren't metering themselves. Conflating the two makes both harder to change independently.
+
+The spec preserves temporal context on observations (instant events vs. time-spanning measurements like compute sessions) so downstream consumers have what they need for proration and period assignment. See [observation-temporal-context.md](design/observation-temporal-context.md).
+
+## Who this is for
+
+You're building a system where:
+
+- customers are billed by what they use — API calls, tokens, compute hours, storage, seats, or any countable resource
+- usage events come from multiple sources with different schemas, and you need a consistent metering layer
+- aggregation isn't just sum — you need peak (max), time-weighted averages, or latest-value gauges
+- billing periods matter — usage windows into hourly, daily, or monthly buckets for invoicing
+- precision matters — you're doing financial math and can't tolerate floating-point drift
+
+If your billing is flat-rate-only, you don't need a metering pipeline.
+
+## Why not just...
+
+- **... a metering platform like [Lago](https://github.com/getlago/lago), [OpenMeter](https://github.com/openmeterio/openmeter), or Stripe Billing?** Those are platforms you deploy or subscribe to. metron is a spec and a library you embed. Pick a platform if you want the whole metering+pricing stack as a vendor-managed thing. Pick metron if you want to own the pipeline and only need the quantity-layer logic.
+- **... shopspring/decimal or apd directly?** metron uses [cockroachdb/apd](https://github.com/cockroachdb/apd) internally, and you could absolutely build metering yourself on top of any decimal library. metron's value is the data shapes (events, configs, records, readings) and the windowing/aggregation logic, not the arithmetic.
+- **... int64 cents?** Fine for currency at a fixed scale. Metering produces values like 11.67 seats or 0.0023 GB-hours — quantities that aren't currency, don't have a fixed scale, and need more than two decimal places.
+
+## Why this design
+
+**Configuration-driven, not code-driven.** Extraction rules, filters, units, and aggregation strategies are all configuration. New products and pricing models update a metering config; engineering doesn't touch the pipeline.
+
+**Pricing-agnostic.** The same pipeline serves usage-based billing (token counts), seat-based pricing (time-weighted averages), hybrid models (both), and flat-rate-with-overage (commit thresholds). The metering layer produces quantities; what those cost is downstream.
+
+**One event, one record.** All observations from a single event bundle into one MeterRecord. Persistence is atomic — all observations save together or none do. No partial event data in the pipeline. See [meterrecord-atomicity-analysis.md](design/references/meterrecord-atomicity-analysis.md).
+
+**No schema coordination.** Event properties are untyped strings. Teams add new properties to their events without coordinating across the metering system. The metering config — not the event schema — decides what gets extracted.
+
+**Replay-safe.** Pure functions with deterministic IDs. Reprocessing the same events with the same configuration produces identical records. No hidden state, no side effects, no order dependence.
+
+**Exact arithmetic.** All quantities are decimal strings (`"123.45"`, not `123.45`). No floating-point anywhere. The Go implementation uses [cockroachdb/apd](https://github.com/cockroachdb/apd) for arbitrary-precision decimal arithmetic.
 
 ## Aggregation strategies
 
@@ -234,7 +155,7 @@ The spec does preserve temporal context on observations (both instant events and
 | **latest** | Current state | Most recent gauge reading |
 | **time-weighted-avg** | Average over time | Seat count across a billing month |
 
-Time-weighted average treats each observation as a step function. This matters when the value changes mid-period: 10 seats for 20 days then 15 seats for 10 days averages to 11.67, not 12.5 (which is what you'd get from a naive mean of the two values). See [aggregation-types.md](design/aggregation-types.md) for the full design rationale.
+Time-weighted average treats each observation as a step function. This matters when the value changes mid-period: 10 seats for 20 days then 15 seats for 10 days averages to 11.67, not 12.5 (which is what a naive mean of the two values would give). See [aggregation-types.md](design/aggregation-types.md).
 
 ## Multi-tenant isolation
 
@@ -243,9 +164,11 @@ Events are scoped by two dimensions:
 - **Workspace** — operational boundary (US region, EU region, a business unit). Each workspace owns its event schemas and metering configs.
 - **Universe** — data namespace (production, test, staging, simulation). The same customer ID in different universes is a different billing entity.
 
-This means you can run test data through the same pipeline as production without cross-contamination, or meter the same customer differently in different regions. See [workspace-universe-isolation.md](design/workspace-universe-isolation.md) for the design rationale.
+You can run test data through the same pipeline as production without cross-contamination, or meter the same customer differently in different regions. See [workspace-universe-isolation.md](design/workspace-universe-isolation.md).
 
 ## Repository structure
+
+The Go reference implementation lives in `internal/`. The portable data contracts — language-agnostic Go structs with JSON tags — live in `specs/`, designed to be re-implemented in any language.
 
 ```
 specs/           Data contracts (language-agnostic Go structs with JSON tags)
@@ -257,12 +180,12 @@ docs/examples/   Walkthrough guides
 benchmarks/      Performance tests
 ```
 
-## Documentation
+## Design notes
 
-- **[Basic API Metering](docs/examples/basic-api-metering.md)** — step-by-step walkthrough with JSON examples
-- **[Workspace-Universe Isolation](design/workspace-universe-isolation.md)** — why two dimensions, not one
-- **[Observation Temporal Context](design/observation-temporal-context.md)** — instant vs. time-spanning observations
-- **[Aggregation Types](design/aggregation-types.md)** — design rationale for aggregation strategies
+- [Observation temporal context](design/observation-temporal-context.md) — instant events vs. time-spanning measurements
+- [Aggregation types](design/aggregation-types.md) — design rationale for sum / max / min / latest / time-weighted-avg
+- [Workspace × universe isolation](design/workspace-universe-isolation.md) — why two dimensions, not one
+- [MeterRecord atomicity](design/references/meterrecord-atomicity-analysis.md) — one event, one record
 
 ## License
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,61 @@
+# Examples
+
+Each directory is a runnable program with a small `main_test.go` that pins the expected output. Run any one with `go run ./examples/<name>` from the metron root, or run the whole suite with `go test ./examples/...`.
+
+| Example | Demonstrates |
+|---|---|
+| [`hello/`](hello/) | Time-weighted gauge — seat counts averaged across a billing window. |
+| [`api-calls/`](api-calls/) | Counter sum — total tokens consumed in a day. |
+| [`llm-tokens/`](llm-tokens/) | Bundled observations — one event with two measurements lands as one record (atomicity). |
+| [`conditional-tier/`](conditional-tier/) | Filters — extract only when a dimension matches (tier-aware billing). |
+| [`compute-session/`](compute-session/) | Time-spanning observations — `[start, end]` windows for activity over a period. |
+
+## Hello world: time-weighted gauge
+
+[`hello/`](hello/) — Two seat-count readings billed as a 30-day time-weighted average. The customer held 10 seats for 20 days then 15 for 10; `time-weighted-avg` returns `11.666…` at full precision (rounded to 11.67 for display). A naive arithmetic mean of 10 and 15 would give 12.5.
+
+```
+customer:acme-corp used 11.67 seats (time-weighted-avg) from 2024-01-01 to 2024-01-31
+```
+
+## Counter sum
+
+[`api-calls/`](api-calls/) — Three API calls on the same day, summed for daily token usage. The most common usage-billing case: total quantity consumed.
+
+```
+customer:acme consumed 2000 tokens on 2024-01-15 (3 events, sum)
+```
+
+## Bundled observations (atomicity)
+
+[`llm-tokens/`](llm-tokens/) — One LLM completion event carries both `input_tokens` and `output_tokens`. The metering config extracts both, and metron returns one `MeterRecord` with two `Observation`s bundled inside it. They persist atomically — either both observations land or neither does — keyed by the source event ID.
+
+```
+event completion_42 -> 1 MeterRecord(s)
+  record completion_42 contains 2 observations:
+    450 input-tokens
+    890 output-tokens
+```
+
+## Conditional metering (filter)
+
+[`conditional-tier/`](conditional-tier/) — Three API requests with mixed `tier` dimensions; the extraction has a `Filter` that only fires when `tier == "premium"`. Free-tier events drop out; premium events get billed under the `premium-tokens` unit.
+
+```
+metered 2/3 events into records (free-tier filtered out)
+sum premium-tokens for the day: 1300 (from 2 events)
+```
+
+## Time-spanning observations
+
+[`compute-session/`](compute-session/) — Three compute sessions, each with an explicit `[start, end]` window, summed for daily compute-hours. Observations carry their own temporal extent: instant `[T, T]` for gauges, spanning `[T1, T2]` for activity over a period.
+
+The `Meter()` helper extracts instant observations from event properties. For richer event shapes that already carry a `[start, end]` window, construct `MeterRecord`s directly using `specs.NewSpanObservation`.
+
+```
+customer:acme used 17 compute-hours across 3 sessions on 2024-01-15
+```
+
+## Adding a new example
+
+Use [`hello/`](hello/) as the template: a small `package main` plus a `main_test.go` that runs `go run .` and asserts the printed output. The test catches drift before the table above goes stale.

--- a/examples/api-calls/main.go
+++ b/examples/api-calls/main.go
@@ -1,0 +1,71 @@
+// Counter sum: total tokens consumed in a day.
+//
+// Three API request events on the same day. Each carries a "tokens" property
+// that gets extracted as an observation; "endpoint" rides through as a
+// dimension. Aggregating with sum gives the day's total token usage.
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/chrisconley/metron/internal"
+	"github.com/chrisconley/metron/specs"
+)
+
+func main() {
+	cfg := specs.MeteringConfigSpec{
+		Observations: []specs.ObservationExtractionSpec{
+			{SourceProperty: "tokens", Unit: "tokens"},
+		},
+	}
+
+	events := []specs.EventPayloadSpec{
+		{
+			ID: "req_1", Type: "api.request",
+			WorkspaceID: "acme", UniverseID: "production",
+			Subject:    "customer:acme",
+			Time:       time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC),
+			Properties: map[string]string{"tokens": "450", "endpoint": "/chat"},
+		},
+		{
+			ID: "req_2", Type: "api.request",
+			WorkspaceID: "acme", UniverseID: "production",
+			Subject:    "customer:acme",
+			Time:       time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC),
+			Properties: map[string]string{"tokens": "1200", "endpoint": "/chat"},
+		},
+		{
+			ID: "req_3", Type: "api.request",
+			WorkspaceID: "acme", UniverseID: "production",
+			Subject:    "customer:acme",
+			Time:       time.Date(2024, 1, 15, 22, 15, 0, 0, time.UTC),
+			Properties: map[string]string{"tokens": "350", "endpoint": "/embed"},
+		},
+	}
+
+	var records []specs.MeterRecordSpec
+	for _, e := range events {
+		recs, err := internal.Meter(e, cfg)
+		if err != nil {
+			log.Fatal(err)
+		}
+		records = append(records, recs...)
+	}
+
+	reading, err := internal.Aggregate(records, nil, specs.AggregateConfigSpec{
+		Aggregation: "sum",
+		Window: specs.TimeWindowSpec{
+			Start: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			End:   time.Date(2024, 1, 16, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	v := reading.ComputedValues[0]
+	fmt.Printf("%s consumed %s %s on 2024-01-15 (%d events, %s)\n",
+		reading.Subject, v.Quantity, v.Unit, reading.RecordCount, v.Aggregation)
+}

--- a/examples/api-calls/main_test.go
+++ b/examples/api-calls/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestAPICallsOutput(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("go", "run", ".")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("go run .: %v\nstderr: %s", err, stderr.String())
+	}
+
+	got := strings.TrimRight(stdout.String(), "\n")
+	want := "customer:acme consumed 2000 tokens on 2024-01-15 (3 events, sum)"
+	if got != want {
+		t.Errorf("examples/README output drift\n got:  %q\n want: %q", got, want)
+	}
+}

--- a/examples/compute-session/main.go
+++ b/examples/compute-session/main.go
@@ -1,0 +1,81 @@
+// Time-spanning observations: compute sessions with explicit [start, end].
+//
+// Each compute session ran for some duration, and the billable quantity is the
+// session's hour count. The session's temporal extent is the observation's
+// own Window — Start < End — distinct from the instant gauge case (Start == End).
+//
+// The Meter() helper extracts instant observations from event properties; for
+// richer event shapes that already carry a [start, end] window, construct
+// MeterRecords directly using NewSpanObservation.
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/chrisconley/metron/internal"
+	"github.com/chrisconley/metron/specs"
+)
+
+func main() {
+	sessions := []struct {
+		id          string
+		start, end  time.Time
+		computeHrs  string
+	}{
+		{
+			id:         "session_1",
+			start:      time.Date(2024, 1, 15, 8, 0, 0, 0, time.UTC),
+			end:        time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC),
+			computeHrs: "4",
+		},
+		{
+			id:         "session_2",
+			start:      time.Date(2024, 1, 15, 14, 0, 0, 0, time.UTC),
+			end:        time.Date(2024, 1, 15, 22, 0, 0, 0, time.UTC),
+			computeHrs: "8",
+		},
+		{
+			id:         "session_3",
+			start:      time.Date(2024, 1, 15, 18, 0, 0, 0, time.UTC),
+			end:        time.Date(2024, 1, 15, 23, 0, 0, 0, time.UTC),
+			computeHrs: "5",
+		},
+	}
+
+	now := time.Date(2024, 1, 16, 0, 0, 1, 0, time.UTC)
+
+	var records []specs.MeterRecordSpec
+	for _, s := range sessions {
+		obs, err := specs.NewSpanObservation(s.computeHrs, "compute-hours", s.start, s.end)
+		if err != nil {
+			log.Fatal(err)
+		}
+		records = append(records, specs.MeterRecordSpec{
+			ID:            s.id,
+			WorkspaceID:   "acme",
+			UniverseID:    "production",
+			Subject:       "customer:acme",
+			ObservedAt:    s.end,
+			Observations:  []specs.ObservationSpec{obs},
+			SourceEventID: s.id,
+			MeteredAt:     now,
+		})
+	}
+
+	reading, err := internal.Aggregate(records, nil, specs.AggregateConfigSpec{
+		Aggregation: "sum",
+		Window: specs.TimeWindowSpec{
+			Start: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			End:   time.Date(2024, 1, 16, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	v := reading.ComputedValues[0]
+	fmt.Printf("%s used %s %s across %d sessions on 2024-01-15\n",
+		reading.Subject, v.Quantity, v.Unit, reading.RecordCount)
+}

--- a/examples/compute-session/main_test.go
+++ b/examples/compute-session/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestComputeSessionOutput(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("go", "run", ".")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("go run .: %v\nstderr: %s", err, stderr.String())
+	}
+
+	got := strings.TrimRight(stdout.String(), "\n")
+	want := "customer:acme used 17 compute-hours across 3 sessions on 2024-01-15"
+	if got != want {
+		t.Errorf("examples/README output drift\n got:  %q\n want: %q", got, want)
+	}
+}

--- a/examples/conditional-tier/main.go
+++ b/examples/conditional-tier/main.go
@@ -1,0 +1,79 @@
+// Conditional metering: extract only when a dimension matches.
+//
+// Three API requests arrive with mixed tier dimensions. The metering config
+// has one extraction with a Filter — extract "tokens" as "premium-tokens"
+// only when the tier dimension equals "premium". Free-tier events produce no
+// observations; premium-tier events do.
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/chrisconley/metron/internal"
+	"github.com/chrisconley/metron/specs"
+)
+
+func main() {
+	cfg := specs.MeteringConfigSpec{
+		Observations: []specs.ObservationExtractionSpec{
+			{
+				SourceProperty: "tokens",
+				Unit:           "premium-tokens",
+				Filter:         &specs.FilterSpec{Property: "tier", Equals: "premium"},
+			},
+		},
+	}
+
+	events := []specs.EventPayloadSpec{
+		{
+			ID: "req_1", Type: "api.request",
+			WorkspaceID: "acme", UniverseID: "production",
+			Subject: "customer:acme",
+			Time:    time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC),
+			Properties: map[string]string{"tokens": "500", "tier": "premium"},
+		},
+		{
+			ID: "req_2", Type: "api.request",
+			WorkspaceID: "acme", UniverseID: "production",
+			Subject: "customer:acme",
+			Time:    time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC),
+			Properties: map[string]string{"tokens": "300", "tier": "free"},
+		},
+		{
+			ID: "req_3", Type: "api.request",
+			WorkspaceID: "acme", UniverseID: "production",
+			Subject: "customer:acme",
+			Time:    time.Date(2024, 1, 15, 16, 0, 0, 0, time.UTC),
+			Properties: map[string]string{"tokens": "800", "tier": "premium"},
+		},
+	}
+
+	var records []specs.MeterRecordSpec
+	for _, e := range events {
+		recs, err := internal.Meter(e, cfg)
+		if err != nil {
+			log.Fatal(err)
+		}
+		records = append(records, recs...)
+	}
+
+	fmt.Printf("metered %d/%d events into records (free-tier filtered out)\n",
+		len(records), len(events))
+
+	reading, err := internal.Aggregate(records, nil, specs.AggregateConfigSpec{
+		Aggregation: "sum",
+		Window: specs.TimeWindowSpec{
+			Start: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			End:   time.Date(2024, 1, 16, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	v := reading.ComputedValues[0]
+	fmt.Printf("%s %s for the day: %s (from %d events)\n",
+		v.Aggregation, v.Unit, v.Quantity, reading.RecordCount)
+}

--- a/examples/conditional-tier/main_test.go
+++ b/examples/conditional-tier/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestConditionalTierOutput(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("go", "run", ".")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("go run .: %v\nstderr: %s", err, stderr.String())
+	}
+
+	got := strings.TrimRight(stdout.String(), "\n")
+	want := strings.Join([]string{
+		"metered 2/3 events into records (free-tier filtered out)",
+		"sum premium-tokens for the day: 1300 (from 2 events)",
+	}, "\n")
+	if got != want {
+		t.Errorf("examples/README output drift\n got:  %q\n want: %q", got, want)
+	}
+}

--- a/examples/llm-tokens/main.go
+++ b/examples/llm-tokens/main.go
@@ -1,0 +1,51 @@
+// Bundled observations: one LLM event, two measurements, one record.
+//
+// An LLM completion event carries both input_tokens and output_tokens. The
+// metering config extracts both, and metron returns one MeterRecord with two
+// Observations bundled inside it. They persist atomically — either both
+// observations land or neither does — keyed by the source event ID. No
+// partial double-billing.
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/chrisconley/metron/internal"
+	"github.com/chrisconley/metron/specs"
+)
+
+func main() {
+	cfg := specs.MeteringConfigSpec{
+		Observations: []specs.ObservationExtractionSpec{
+			{SourceProperty: "input_tokens", Unit: "input-tokens"},
+			{SourceProperty: "output_tokens", Unit: "output-tokens"},
+		},
+	}
+
+	event := specs.EventPayloadSpec{
+		ID: "completion_42", Type: "llm.completion",
+		WorkspaceID: "acme", UniverseID: "production",
+		Subject: "customer:acme",
+		Time:    time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+		Properties: map[string]string{
+			"input_tokens":  "450",
+			"output_tokens": "890",
+			"model":         "gpt-4",
+		},
+	}
+
+	records, err := internal.Meter(event, cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("event %s -> %d MeterRecord(s)\n", event.ID, len(records))
+	for _, r := range records {
+		fmt.Printf("  record %s contains %d observations:\n", r.ID, len(r.Observations))
+		for _, obs := range r.Observations {
+			fmt.Printf("    %s %s\n", obs.Quantity, obs.Unit)
+		}
+	}
+}

--- a/examples/llm-tokens/main_test.go
+++ b/examples/llm-tokens/main_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestLLMTokensOutput(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("go", "run", ".")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("go run .: %v\nstderr: %s", err, stderr.String())
+	}
+
+	got := strings.TrimRight(stdout.String(), "\n")
+	want := strings.Join([]string{
+		"event completion_42 -> 1 MeterRecord(s)",
+		"  record completion_42 contains 2 observations:",
+		"    450 input-tokens",
+		"    890 output-tokens",
+	}, "\n")
+	if got != want {
+		t.Errorf("examples/README output drift\n got:  %q\n want: %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Three groups of changes on this branch.

### README rewrite (804582c)

Restructures the README to lead with pipeline shape and scope before explaining design choices. Promotes Scope to a first-class fit-qualifier with explicit anti-features (`metron does NOT...`), adds a `Why not just...` section comparing against metering platforms / decimal libraries / int64 cents, and compresses the inline Go example from 60 lines to ~22 by dropping display-formatting plumbing. The pre-1.0 callout becomes a `> [!WARNING]` GitHub alert. Patterns drawn from `quanta/docs/tmp/oss-readme/_synthesis.md`, `oss-readme-libs/_synthesis.md`, and `readme-exemplars.md`.

Also adds a placeholder `## Where it fits` section (TODO body) between Core idea and Why this design — content to follow in a separate change once the system-position diagram is finalized.

### Runnable examples + index — `examples/` (72a9128)

Four new runnable examples beyond `hello/`, each with a `main_test.go` that pins expected output so the index can't drift:

- `api-calls/` — counter sum, total tokens for the day
- `llm-tokens/` — bundled observations, demonstrates per-event atomicity (one event, two measurements, one record)
- `conditional-tier/` — `Filter` on a dimension (only meter when `tier == "premium"`)
- `compute-session/` — time-spanning observations via `specs.NewSpanObservation`

`examples/README.md` indexes them with one-line capability descriptions and verified outputs. The `## What's in this repo` and repo-layout sections of the main README now point at the expanded tree.

### GitHub Actions CI (cf8d0b2)

Adds `.github/workflows/test.yml` (runs `go test ./...` on PRs against `main` with non-doc paths and on pushes to `main`) and `.github/workflows/test-docs-only.yml` (companion no-op that satisfies a required `test` status check for doc-only PRs without spinning up Go). Mirrors the certus pattern, with metron's doc paths (`docs/`, `arch/`, `design/`, `**.md`).

The `verocorp/go-ddd` action was tried locally and fails across the board (every VO missing `MustNewX`, 0 / 36 `Test*_Equality` coverage, 23 `.String()` violations in non-accessor tests). Bringing metron into compliance is tracked separately as #12; not blocking CI today.

## Test plan

- [x] `go test ./...` green on the full tree, including the five example output assertions
- [x] Each new example runs cleanly via `go run ./examples/<name>`
- [ ] CI workflows fire on this PR's first push and stay green
- [ ] After merge: enable required `test` check in branch protection on `main`

## Notes

- The clone URL in the new README points at `github.com/chrisconley/metron` (matches `go.mod`); the repo is `verocorp/metron`. Flagging in case `go.mod` should be updated separately.